### PR TITLE
docs: update model references and improve documentation clarity

### DIFF
--- a/.meowg1k/config.yaml
+++ b/.meowg1k/config.yaml
@@ -1,16 +1,16 @@
 profiles:
   fast:
     provider: "openrouter"
-    model: "qwen/qwen3-coder:free"
-    requestsPerMinute: 1000
-    tokensPerMinute: 2000000
+    model: "qwen/qwen3-coder-flash"
+    requestsPerMinute: 60
+    tokensPerMinute: 1000000
     requestsPerDay: 10000
 
   smart:
     provider: "openrouter"
-    model: "qwen/qwen3-coder:free"
+    model: "qwen/qwen3-coder-plus"
     timeout: "10m"
-    requestsPerMinute: 150
+    requestsPerMinute: 60
     tokensPerMinute: 1000000
     requestsPerDay: 10000
 

--- a/.meowg1k/config.yaml
+++ b/.meowg1k/config.yaml
@@ -1,14 +1,14 @@
 profiles:
   fast:
-    provider: "gemini"
-    model: "gemini-2.5-flash"
+    provider: "openrouter"
+    model: "qwen/qwen3-coder:free"
     requestsPerMinute: 1000
     tokensPerMinute: 2000000
     requestsPerDay: 10000
 
   smart:
-    provider: "gemini"
-    model: "gemini-2.5-pro"
+    provider: "openrouter"
+    model: "qwen/qwen3-coder:free"
     timeout: "10m"
     requestsPerMinute: 150
     tokensPerMinute: 1000000

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ Explore the full documentation to master `meowg1k`. For a complete overview, jum
 
   *Automate your workflow with Git hooks and CI/CD pipelines.*
 
-- [**Core Principles**](./docs/06-PRINCIPLES.md)
+- [**Project Philosophy & Core Principles**](./docs/06-PRINCIPLES.md)
 
   *Understand the philosophy and vision behind the project.*
 
-- [**FAQ**](./docs/07-FAQ.md)
+- [**Frequently Asked Questions (FAQ)**](./docs/07-FAQ.md)
 
   *Find answers to common questions.*
 

--- a/docs/07-FAQ.md
+++ b/docs/07-FAQ.md
@@ -9,7 +9,7 @@ This document answers common questions about `meowg1k`.
 ### Q: Which provider should I use?
 
 - **For beginners:** Gemini (`gemini-2.5-flash`) offers a generous free tier and is very fast.
-- **For quality:** Anthropic Claude (`claude-4-5-sonnet`) provides excellent, high-quality output.
+- **For quality:** Anthropic Claude (`claude-sonnet-4-5-20250929`) provides excellent, high-quality output.
 - **For cost-effectiveness:** OpenRouter gives you access to many free and low-cost models.
 - **For privacy:** Use a local `llama.cpp` server for complete data privacy.
 
@@ -69,8 +69,6 @@ While comprehensive debug logging is planned for a future release, you can curre
 3. **Provider dashboards:** Most AI providers (OpenAI, Anthropic, Gemini) offer request logs and usage dashboards where you can see the exact prompts and tokens sent.
 4. **Small test cases:** Create minimal test inputs and verify the output to build confidence in what's being processed.
 5. **Local models:** For complete transparency, use a local `llama.cpp` server where you can enable verbose logging on the server side to see all requests.
-
-A `--verbose` flag for detailed request logging is on the roadmap for future versions.
 
 ### Q: What happens if I hit my provider's rate limits?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,6 @@ This page provides a complete index of the `meowg1k` documentation.
 
 ## Reference & Help
 
-- [06 - Core Principles](./06-PRINCIPLES.md)
+- [06 - Project Philosophy & Core Principles](./06-PRINCIPLES.md)
 - [07 - Frequently Asked Questions (FAQ)](./07-FAQ.md)
 - [08 - Troubleshooting Guide](./08-TROUBLESHOOTING.md)


### PR DESCRIPTION
## Summary
This pull request updates the project configuration to migrate from Google's Gemini models to OpenRouter's Qwen models, along with corresponding documentation updates to reflect the new model versions and improved navigation. The changes include adjustments to rate limits and minor textual improvements in the documentation for better clarity.

## Motivation
The primary motivation for these changes is to transition the project's AI model provider from Google's Gemini to OpenRouter's Qwen models. This shift aims to leverage different capabilities, performance characteristics, or cost structures of the Qwen models. Additionally, the documentation updates improve navigational clarity and ensure that users have access to the most current information regarding supported models and project principles.

## Changes
- **Configuration**: Updated `.meowg1k/config.yaml` to switch from Gemini to Qwen models and adjusted rate limits.
- **Documentation**: Enhanced hyperlink text in `README.md` for better clarity.
- **Documentation**: Updated model version in `docs/07-FAQ.md` and removed mention of verbose logging flag.
- **Documentation**: Renamed link in `docs/README.md` for more descriptive core principles documentation.

## Breaking Changes
None