### PR TITLE
feat(cli): introduce "flat" strategy for faster commits and PRs

### DIFF
--- a/cmd/default_config.yaml
+++ b/cmd/default_config.yaml
@@ -93,6 +93,10 @@ summarize:
 commit:
   default:
     profile: "smart"
+    # Strategy determines how changes are processed:
+    # - "summarize" (default): Map-Reduce approach, summarizes each file then composes the final message
+    # - "flat": Sends entire diff directly to the model without summarization (faster for small commits)
+    # strategy: "summarize"
     systemPrompt: >-
       You are a Git commit message expert.
       Generate clear, concise commit messages following conventional commits format.
@@ -101,6 +105,10 @@ commit:
 pullRequest:
   default:
     profile: "smart"
+    # Strategy determines how changes are processed:
+    # - "summarize" (default): Map-Reduce approach, summarizes each file then composes the final description
+    # - "flat": Sends entire diff directly to the model without summarization (faster for small PRs)
+    # strategy: "summarize"
     systemPrompt: >-
       You are a technical writer specializing in pull request descriptions.
       Generate comprehensive PR descriptions that explain:

--- a/docs/02-CONFIGURATION.md
+++ b/docs/02-CONFIGURATION.md
@@ -112,7 +112,7 @@ models:
   # A powerful model for complex reasoning
   claude-sonnet:
     provider: "anthropic"
-    model: "claude-3-5-sonnet-20240620"
+    model: "claude-sonnet-4-5-20250929"
     maxInputTokens: 180000
 
   # A model for a local llama.cpp server
@@ -230,6 +230,19 @@ These top-level sections configure the specific commands.
 - **`generate`**: Define pre-set tasks for the `meow generate -t <task-name>` command.
 - **`commit` / `pullrequest`**: Configure the final "Reduce" phase, where individual file summaries are combined into a single commit message or PR description.
 
+#### Strategy Field
+
+Both `commit` and `pullrequest` commands support a `strategy` field that determines how changes are processed:
+
+- **`"summarize"` (default)**: Uses a Map-Reduce approach. Each changed file is summarized individually (the "Map" phase), then all summaries are combined to generate the final commit message or PR description (the "Reduce" phase). This strategy is ideal for large commits with many files, as it allows the model to focus on each file separately before synthesizing the overall message.
+
+- **`"flat"`**: Sends the entire git diff directly to the model without any intermediate summarization. This is faster and more efficient for small commits (e.g., a single file or a few lines of changes), as it eliminates the overhead of the Map-Reduce pipeline. However, if the diff size exceeds the model's `maxInputTokens` limit, the command will fail with an error suggesting you switch to the `"summarize"` strategy.
+
+**When to use each strategy:**
+
+- Use `"flat"` for quick, small commits (< 5 files, simple changes)
+- Use `"summarize"` (default) for larger changesets, complex refactorings, or when you need detailed per-file analysis
+
 ```yaml
 generate:
   default:
@@ -244,6 +257,7 @@ generate:
 
 commit:
   profile: "smart"
+  strategy: "summarize"  # Optional: "summarize" (default) or "flat"
   systemPrompt: |
     You are an expert software engineer reviewing code changes. Your task is to write a high-quality commit message in the Conventional Commits format based on the provided summaries of file changes.
 
@@ -256,6 +270,7 @@ commit:
 
 pullRequest:
   profile: "smart"
+  strategy: "summarize"  # Optional: "summarize" (default) or "flat"
   systemPrompt: |
     You are an expert software engineer tasked with writing a Pull Request description. Based on the summaries of file changes, generate a complete PR description in Markdown format.
 
@@ -337,7 +352,7 @@ models:
       requestsPerMinute: 30
   claude-sonnet:
     provider: "anthropic"
-    model: "claude-3-5-sonnet-20240620"
+    model: "claude-sonnet-4-5-20250929"
 
 profiles:
   fast:

--- a/docs/03-COMMAND-REFERENCE.md
+++ b/docs/03-COMMAND-REFERENCE.md
@@ -102,6 +102,13 @@ echo "function add(a, b) { return a + b; }" | meow g \
 
 Generates a commit message based on staged changes or the difference between branches.
 
+The command supports two execution strategies (configured via the `commit.strategy` field in your config file):
+
+- **`summarize` (default)**: Uses a Map-Reduce approach, analyzing each file individually then combining summaries. Best for large commits.
+- **`flat`**: Sends the entire diff directly to the model. Faster for small commits, but fails if the diff is too large.
+
+See the [Configuration Guide](./02-CONFIGURATION.md) for details on configuring the strategy.
+
 ### Usage
 
 ```bash
@@ -148,16 +155,23 @@ meow commit -t dev -i "Implement the entire user profile feature"
 
 Generates a Pull Request title and description based on the difference between your current branch and a base branch.
 
+The command supports two execution strategies (configured via the `pullRequest.strategy` field in your config file):
+
+- **`summarize` (default)**: Uses a Map-Reduce approach, analyzing each file individually then combining summaries. Best for large PRs.
+- **`flat`**: Sends the entire diff directly to the model. Faster for small PRs, but fails if the diff is too large.
+
+See the [Configuration Guide](./02-CONFIGURATION.md) for details on configuring the strategy.
+
 ### Usage
 
 ```bash
-meow pullrequest [flags]
+meow pullrequest --base <branch> [flags]
 ```
 
 ### Flags
 
-- `-b, --base <branch>`: **(Required)** The base branch you intend to merge into (e.g., `main`, `dev`).
-- `-i, --intent <text>`: Provides a high-level developer intent for the PR, which helps the AI generate a more accurate title and description. Can also be provided via stdin.
+- `-b, --base <branch>`: **(Required)** The base branch to compare against (e.g., `main`, `dev`, `master`).
+- `-i, --intent <text>`: Provides high-level context or intent for the PR. Can also be provided via stdin.
 
 ### Examples
 

--- a/docs/04-EXAMPLES.md
+++ b/docs/04-EXAMPLES.md
@@ -37,7 +37,7 @@ For tasks you perform often, like code reviews or security checks, defining a ta
 models:
   claude-sonnet:
     provider: "anthropic"
-    model: "claude-3-5-sonnet-20240620"
+    model: "claude-sonnet-4-5-20250929"
 
 profiles:
   claude-secure:
@@ -77,10 +77,10 @@ This example shows the power of the `summarize` and `commit` workflow.
 models:
   gemini-flash:
     provider: "gemini"
-    model: "gemini-1.5-flash-latest"
+    model: "gemini-2.5-flash"
   claude-sonnet:
     provider: "anthropic"
-    model: "claude-3-5-sonnet-20240620"
+    model: "claude-sonnet-4-5-20250929"
 
 profiles:
   fast:
@@ -116,7 +116,63 @@ meow commit -i "Fix the user login bug and refactor token handling"
 
 ---
 
-## 4. Advanced PR Descriptions with File-Specific Rules
+## 4. Fast Commit Messages for Small Changes
+
+For quick, small commits (single file changes or minor tweaks), the full Map-Reduce workflow can be overkill. The `flat` strategy sends the entire diff directly to the model, making it much faster.
+
+**Goal:** Generate commit messages quickly for small, incremental changes during development.
+
+**Configuration (`.meowg1k/config.yaml`):**
+
+```yaml
+models:
+  gemini-flash:
+    provider: "gemini"
+    model: "gemini-2.5-flash"
+
+profiles:
+  fast:
+    model: "gemini-flash"
+
+commit:
+  profile: "fast"
+  strategy: "flat"  # Skip the summarize step, send diff directly
+  systemPrompt: |
+    You are an expert software engineer. Write a concise commit message in Conventional Commits format based on this git diff.
+    Be brief and focus on what changed and why.
+```
+
+**Command:**
+
+```bash
+# Make a small change
+echo "// TODO: Add validation" >> service.go
+git add service.go
+
+# Generate a quick commit message
+meow commit
+```
+
+**Explanation:**
+
+- With `strategy: "flat"`, `meowg1k` bypasses the file-by-file summarization and sends the complete diff directly to the LLM.
+- This is ideal for small commits where the context fits easily within the model's token limit.
+- If the diff is too large (exceeds `maxInputTokens`), the command will fail with a helpful error suggesting you switch back to `strategy: "summarize"`.
+
+**When to use `flat` vs `summarize`:**
+
+- Use `flat` for:
+  - Single file changes
+  - Minor bug fixes or typos
+  - Quick iterative development
+- Use `summarize` (default) for:
+  - Multi-file refactorings
+  - Large feature implementations
+  - Complex changes that benefit from per-file analysis
+
+---
+
+## 5. Advanced PR Descriptions with File-Specific Rules
 
 This recipe demonstrates how to use advanced `summarize` rules to generate a highly accurate and structured PR description.
 

--- a/docs/08-TROUBLESHOOTING.md
+++ b/docs/08-TROUBLESHOOTING.md
@@ -162,7 +162,7 @@ meow commit --target-branch main
 profiles:
     slow-model:
     provider: "anthropic"
-    model: "claude-3-5-sonnet-20240620"
+    model: "claude-sonnet-4-5-20250929"
     timeout: "15m" # Increase timeout to 15 minutes
 ```
 

--- a/docs/man/meow-commit.1
+++ b/docs/man/meow-commit.1
@@ -25,15 +25,20 @@ flag is provided, analyzes the diff between the current branch and the
 specified target branch. This is useful for generating a single commit message
 that summarizes all changes before merging.
 .PP
-The command uses a two-phase "Map-Reduce" approach:
+The command supports two execution strategies (configured in the
+.B commit
+section):
+.PP
+.B Summarize Strategy (default):
+Uses a two-phase "Map-Reduce" approach:
 .IP "1." 3
-\fBMap Phase (Summarize):\fR Each changed file is analyzed individually using
+\fBMap Phase:\fR Each changed file is analyzed individually using
 the configuration from the
 .B summarize
 section. Different files can use different profiles and prompts based on
 pattern-matching rules.
 .IP "2."
-\fBReduce Phase (Commit):\fR The individual file summaries are combined and
+\fBReduce Phase:\fR The individual file summaries are combined and
 sent to the AI to generate the final commit message using the configuration
 from the
 .B commit
@@ -41,6 +46,13 @@ section.
 .PP
 This approach optimizes for both quality (using powerful models where needed)
 and cost (using fast, cheap models for routine analysis).
+.PP
+.B Flat Strategy:
+Sends the entire git diff directly to the model in a single request. This is
+faster and more efficient for small commits (e.g., a single file or a few
+lines of changes), as it eliminates the overhead of the Map-Reduce pipeline.
+However, if the diff size exceeds the model's token limit, the command will
+fail with an error suggesting you switch to the "summarize" strategy.
 
 .SH OPTIONS
 .TP
@@ -94,15 +106,27 @@ summarize:
 .PP
 .B commit
 (required): Configure the Reduce phase where file summaries are combined
-into the final commit message:
+into the final commit message. Also controls the execution strategy:
 .PP
 .nf
 commit:
   profile: "smart"
+  strategy: "summarize"  # or "flat" for small commits
   systemPrompt: |
     You are an expert software engineer. Write a commit message
     in Conventional Commits format based on the file summaries.
 .fi
+.PP
+The
+.B strategy
+field (optional, default: "summarize") determines how the commit message
+is generated:
+.IP \[bu] 2
+\fB"summarize"\fR: Uses the full Map-Reduce workflow. Best for commits
+with many files or complex changes.
+.IP \[bu]
+\fB"flat"\fR: Sends the raw git diff directly to the model. Faster for
+small commits (single file or minor changes). Fails if diff is too large.
 .PP
 See
 .BR meow\-config (5)

--- a/docs/man/meow-config.5
+++ b/docs/man/meow-config.5
@@ -161,6 +161,19 @@ Fields:
 .IP \[bu]
 \fBsystemPrompt\fR: System prompt that guides commit message generation.
 Should include format instructions (e.g., Conventional Commits format).
+.IP \[bu]
+\fBstrategy\fR: Execution strategy (optional). One of:
+.RS
+.IP \[bu] 2
+\fB"summarize"\fR (default): Uses the Map-Reduce approach. Each file is
+analyzed individually, then summaries are combined to create the commit message.
+Best for large commits with many files.
+.IP \[bu]
+\fB"flat"\fR: Sends the entire git diff directly to the model without
+intermediate summarization. Faster and more efficient for small commits
+(e.g., single file or a few lines). Will fail if diff exceeds model's
+token limit.
+.RE
 
 .SS pullRequest
 Configuration for the "Reduce" phase of the pullrequest command. Individual file
@@ -172,6 +185,19 @@ Fields:
 .IP \[bu]
 \fBsystemPrompt\fR: System prompt that guides PR description generation.
 Should include template and format instructions.
+.IP \[bu]
+\fBstrategy\fR: Execution strategy (optional). One of:
+.RS
+.IP \[bu] 2
+\fB"summarize"\fR (default): Uses the Map-Reduce approach. Each file is
+analyzed individually, then summaries are combined to create the PR description.
+Best for large PRs with many files.
+.IP \[bu]
+\fB"flat"\fR: Sends the entire git diff directly to the model without
+intermediate summarization. Faster and more efficient for small PRs
+(e.g., a few files or simple changes). Will fail if diff exceeds model's
+token limit.
+.RE
 
 .SH PROVIDER DEFAULTS
 Each provider has smart defaults for model selection and API key environment
@@ -258,7 +284,7 @@ profiles:
 
   claude-smart:
     provider: "anthropic"
-    model: "claude-3-5-sonnet-20240620"
+    model: "claude-sonnet-4-5-20250929"
     maxInputTokens: 180000
     timeout: "10m"
     requestsPerMinute: 20
@@ -400,7 +426,7 @@ profiles:
 
   quality:
     provider: "anthropic"
-    model: "claude-3-5-sonnet-20240620"
+    model: "claude-sonnet-4-5-20250929"
 
   embeddings:
     provider: "voyage"

--- a/docs/man/meow-pullrequest.1
+++ b/docs/man/meow-pullrequest.1
@@ -15,17 +15,21 @@ between your current branch and a specified base branch. It creates
 comprehensive, Markdown-formatted PR descriptions suitable for GitHub,
 GitLab, Bitbucket, and other code review platforms.
 .PP
-The command uses the same two-phase "Map-Reduce" approach as
-.BR meow\-commit (1):
+The command supports two execution strategies (configured in the
+.B pullRequest
+section):
+.PP
+.B Summarize Strategy (default):
+Uses a two-phase "Map-Reduce" approach:
 .IP "1." 3
-\fBMap Phase (Summarize):\fR Each changed file is analyzed individually using
+\fBMap Phase:\fR Each changed file is analyzed individually using
 the configuration from the
 .B summarize
 section. Different files can use different profiles and prompts based on
 pattern-matching rules. Files can also be skipped entirely (e.g., documentation,
 generated files).
 .IP "2."
-\fBReduce Phase (Pull Request):\fR The individual file summaries are combined and
+\fBReduce Phase:\fR The individual file summaries are combined and
 sent to the AI to generate the final PR description using the configuration
 from the
 .B pullRequest
@@ -34,6 +38,13 @@ section.
 This approach allows you to optimize for both quality (using powerful models
 for critical files) and cost (using fast, cheap models or skipping non-critical
 files).
+.PP
+.B Flat Strategy:
+Sends the entire git diff directly to the model in a single request. This is
+faster and more efficient for small PRs (e.g., a few files or simple changes),
+as it eliminates the overhead of the Map-Reduce pipeline. However, if the
+diff size exceeds the model's token limit, the command will fail with an
+error suggesting you switch to the "summarize" strategy.
 
 .SH OPTIONS
 .TP
@@ -105,12 +116,12 @@ summarize:
 .PP
 .B pullRequest
 (required): Configure the Reduce phase where file summaries are combined
-into the final PR description. Should define the format and structure of
-the output:
+into the final PR description. Also controls the execution strategy:
 .PP
 .nf
 pullRequest:
   profile: "smart"
+  strategy: "summarize"  # or "flat" for small PRs
   systemPrompt: |
     You are an expert software engineer writing a Pull Request.
     Based on file summaries, generate a PR description in Markdown:
@@ -125,6 +136,17 @@ pullRequest:
     ## How to Test
     1. Step-by-step testing instructions
 .fi
+.PP
+The
+.B strategy
+field (optional, default: "summarize") determines how the PR description
+is generated:
+.IP \[bu] 2
+\fB"summarize"\fR: Uses the full Map-Reduce workflow. Best for PRs
+with many files or complex changes.
+.IP \[bu]
+\fB"flat"\fR: Sends the raw git diff directly to the model. Faster for
+small PRs (few files or minor changes). Fails if diff is too large.
 .PP
 See
 .BR meow\-config (5)
@@ -169,7 +191,7 @@ profiles:
     model: "gemini-2.5-flash"
   smart:
     provider: "anthropic"
-    model: "claude-3-5-sonnet-20240620"
+    model: "claude-sonnet-4-5-20250929"
 
 filter:
   ignore:

--- a/docs/man/meow.1
+++ b/docs/man/meow.1
@@ -257,7 +257,7 @@ profiles:
     provider: "gemini"
   smart:
     provider: "anthropic"
-    model: "claude-3-5-sonnet-20240620"
+    model: "claude-sonnet-4-5-20250929"
 
 generate:
   default:

--- a/internal/activities/composeflat/activity.go
+++ b/internal/activities/composeflat/activity.go
@@ -1,0 +1,155 @@
+/*
+Copyright © 2025 Andrew Vasilyev <me@retran.me>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package composeflat provides a generic activity for composing content using the full diff.
+// This is a shared implementation used by both commit and PR flat strategies.
+package composeflat
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/retran/meowg1k/internal/activities/invokellm"
+	"github.com/retran/meowg1k/internal/domain/git"
+	"github.com/retran/meowg1k/internal/domain/profile"
+	"github.com/retran/meowg1k/pkg/executor"
+)
+
+// Input defines the input structure for the ComposeFlat activity.
+type Input struct {
+	Profile      *profile.ResolvedProfile
+	SystemPrompt string
+	Changes      []*git.FileChange
+	Intent       string // Optional developer intent
+}
+
+// Output defines the output structure for the ComposeFlat activity.
+type Output struct {
+	Content string // Generic content output (commit message or PR description)
+}
+
+// Factory creates instances of the ComposeFlat activity with injected dependencies.
+type Factory struct {
+	contentGenerationActivityFactory executor.ActivityFactory[*invokellm.Input, *invokellm.Output]
+	activityName                     string // For progress messages
+	contentType                      string // For error messages (e.g., "commit message", "PR description")
+}
+
+// Compile-time check to ensure Factory implements ActivityFactory interface
+var _ executor.ActivityFactory[*Input, *Output] = (*Factory)(nil)
+
+// NewFactory creates a new ComposeFlat activity factory with the provided content generation activity factory.
+// activityName is used in progress messages (e.g., "Composing commit message using flat strategy")
+// contentType is used in error messages (e.g., "failed to generate commit message")
+func NewFactory(
+	contentGenerationActivityFactory executor.ActivityFactory[*invokellm.Input, *invokellm.Output],
+	activityName string,
+	contentType string,
+) (*Factory, error) {
+	if contentGenerationActivityFactory == nil {
+		return nil, fmt.Errorf("content generation activity factory cannot be nil")
+	}
+
+	if activityName == "" {
+		activityName = "Composing content using flat strategy"
+	}
+
+	if contentType == "" {
+		contentType = "content"
+	}
+
+	return &Factory{
+		contentGenerationActivityFactory: contentGenerationActivityFactory,
+		activityName:                     activityName,
+		contentType:                      contentType,
+	}, nil
+}
+
+// NewActivity creates and returns the ComposeFlat activity function with added progress reporting.
+func (f *Factory) NewActivity() executor.Activity[*Input, *Output] {
+	return func(ctx context.Context, executorCtx *executor.Context, input *Input) (*Output, error) {
+		if f == nil {
+			return nil, fmt.Errorf("compose flat factory is nil")
+		}
+
+		if input == nil {
+			return nil, fmt.Errorf("input cannot be nil")
+		}
+
+		executorCtx.SendRunning(f.activityName)
+
+		// Estimate token count (rough approximation: 1 token ≈ 4 characters)
+		var totalChars int
+		for _, change := range input.Changes {
+			totalChars += len(change.Change)
+		}
+		estimatedTokens := totalChars / 4
+
+		// Check if the estimated tokens exceed the profile's max input tokens
+		if input.Profile.MaxInputTokens > 0 && estimatedTokens > input.Profile.MaxInputTokens {
+			return nil, fmt.Errorf(
+				"diff is too large for 'flat' strategy: estimated %d tokens exceeds profile limit of %d tokens. Consider using 'summarize' strategy instead",
+				estimatedTokens,
+				input.Profile.MaxInputTokens,
+			)
+		}
+
+		// Build the content with full diffs
+		var contentBuilder strings.Builder
+		contentBuilder.WriteString("Git Diff:\n\n")
+
+		for _, change := range input.Changes {
+			contentBuilder.WriteString(fmt.Sprintf("File: %s\n", change.Filename))
+			contentBuilder.WriteString("```diff\n")
+			contentBuilder.WriteString(change.Change)
+			contentBuilder.WriteString("\n```\n\n")
+		}
+
+		if input.Intent != "" {
+			contentBuilder.WriteString(fmt.Sprintf("\nDeveloper Intent: %s\n", input.Intent))
+		}
+
+		content := contentBuilder.String()
+
+		contentGenerationActivity := f.contentGenerationActivityFactory.NewActivity()
+
+		invokeInput := &invokellm.Input{
+			Profile:      input.Profile,
+			SystemPrompt: input.SystemPrompt,
+			UserPrompt:   content,
+		}
+
+		invokeFuture := executor.ExecuteActivity[*invokellm.Input, *invokellm.Output](
+			executorCtx.GetExecutor(),
+			ctx,
+			executorCtx,
+			"GenerateContent",
+			contentGenerationActivity,
+			invokeInput,
+		)
+		invokeOutput, err := invokeFuture.Get(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate %s: %w", f.contentType, err)
+		}
+
+		executorCtx.SendCompleted("")
+
+		return &Output{
+			Content: invokeOutput.Content,
+		}, nil
+	}
+}

--- a/internal/activities/composeflat/activity_test.go
+++ b/internal/activities/composeflat/activity_test.go
@@ -1,0 +1,226 @@
+/*
+Copyright © 2025 Andrew Vasilyev <me@retran.me>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package composeflat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/retran/meowg1k/internal/activities/invokellm"
+	"github.com/retran/meowg1k/internal/domain/git"
+	"github.com/retran/meowg1k/internal/domain/profile"
+	"github.com/retran/meowg1k/pkg/executor"
+)
+
+// Mock activity factory for content generation
+type mockContentGenerationFactory struct {
+	response string
+	err      error
+}
+
+func (m *mockContentGenerationFactory) NewActivity() executor.Activity[*invokellm.Input, *invokellm.Output] {
+	return func(ctx context.Context, executorCtx *executor.Context, input *invokellm.Input) (*invokellm.Output, error) {
+		if m.err != nil {
+			return nil, m.err
+		}
+		return &invokellm.Output{Content: m.response}, nil
+	}
+}
+
+func TestNewFactory(t *testing.T) {
+	t.Run("valid factory creation", func(t *testing.T) {
+		mockFactory := &mockContentGenerationFactory{response: "test"}
+		factory, err := NewFactory(mockFactory, "test activity", "test content")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if factory == nil {
+			t.Fatal("expected factory to be non-nil")
+		}
+	})
+
+	t.Run("nil content generation factory", func(t *testing.T) {
+		factory, err := NewFactory(nil, "test", "test")
+		if err == nil {
+			t.Fatal("expected error for nil factory")
+		}
+		if factory != nil {
+			t.Fatal("expected nil factory")
+		}
+	})
+
+	t.Run("default values for empty strings", func(t *testing.T) {
+		mockFactory := &mockContentGenerationFactory{response: "test"}
+		factory, err := NewFactory(mockFactory, "", "")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if factory.activityName == "" {
+			t.Error("expected default activity name")
+		}
+		if factory.contentType == "" {
+			t.Error("expected default content type")
+		}
+	})
+}
+
+func TestComposeFlat(t *testing.T) {
+	t.Run("successful composition", func(t *testing.T) {
+		mockFactory := &mockContentGenerationFactory{response: "Generated content"}
+		factory, err := NewFactory(mockFactory, "Test activity", "test content")
+		if err != nil {
+			t.Fatalf("failed to create factory: %v", err)
+		}
+
+		activity := factory.NewActivity()
+		exec := executor.NewExecutor()
+		execCtx := executor.NewContext("test", nil, exec)
+
+		input := &Input{
+			Profile: &profile.ResolvedProfile{
+				MaxInputTokens: 10000,
+			},
+			SystemPrompt: "Test system prompt",
+			Changes: []*git.FileChange{
+				{
+					Filename: "test.go",
+					Change:   "+func test() {}",
+				},
+			},
+			Intent: "Test intent",
+		}
+
+		output, err := activity(context.Background(), execCtx, input)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if output.Content != "Generated content" {
+			t.Errorf("expected 'Generated content', got %q", output.Content)
+		}
+	})
+
+	t.Run("nil factory", func(t *testing.T) {
+		var factory *Factory
+		activity := factory.NewActivity()
+		exec := executor.NewExecutor()
+		execCtx := executor.NewContext("test", nil, exec)
+
+		input := &Input{
+			Profile: &profile.ResolvedProfile{},
+		}
+
+		_, err := activity(context.Background(), execCtx, input)
+		if err == nil {
+			t.Fatal("expected error for nil factory")
+		}
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		mockFactory := &mockContentGenerationFactory{response: "test"}
+		factory, _ := NewFactory(mockFactory, "test", "test")
+		activity := factory.NewActivity()
+		exec := executor.NewExecutor()
+		execCtx := executor.NewContext("test", nil, exec)
+
+		_, err := activity(context.Background(), execCtx, nil)
+		if err == nil {
+			t.Fatal("expected error for nil input")
+		}
+	})
+
+	t.Run("diff too large", func(t *testing.T) {
+		mockFactory := &mockContentGenerationFactory{response: "test"}
+		factory, _ := NewFactory(mockFactory, "test", "test content")
+		activity := factory.NewActivity()
+		exec := executor.NewExecutor()
+		execCtx := executor.NewContext("test", nil, exec)
+
+		// Create a large change
+		largeChange := ""
+		for i := 0; i < 10000; i++ {
+			largeChange += "+line\n"
+		}
+
+		input := &Input{
+			Profile: &profile.ResolvedProfile{
+				MaxInputTokens: 100, // Very small limit
+			},
+			SystemPrompt: "Test",
+			Changes: []*git.FileChange{
+				{
+					Filename: "test.go",
+					Change:   largeChange,
+				},
+			},
+		}
+
+		_, err := activity(context.Background(), execCtx, input)
+		if err == nil {
+			t.Fatal("expected error for diff too large")
+		}
+		if !contains(err.Error(), "diff is too large") {
+			t.Errorf("expected 'diff is too large' error, got %v", err)
+		}
+	})
+
+	t.Run("multiple files with intent", func(t *testing.T) {
+		mockFactory := &mockContentGenerationFactory{response: "Multi-file content"}
+		factory, _ := NewFactory(mockFactory, "test", "test content")
+		activity := factory.NewActivity()
+		exec := executor.NewExecutor()
+		execCtx := executor.NewContext("test", nil, exec)
+
+		input := &Input{
+			Profile: &profile.ResolvedProfile{
+				MaxInputTokens: 50000,
+			},
+			SystemPrompt: "Test",
+			Changes: []*git.FileChange{
+				{
+					Filename: "file1.go",
+					Change:   "+func test1() {}",
+				},
+				{
+					Filename: "file2.go",
+					Change:   "+func test2() {}",
+				},
+			},
+			Intent: "Add new functions",
+		}
+
+		output, err := activity(context.Background(), execCtx, input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if output.Content != "Multi-file content" {
+			t.Errorf("expected 'Multi-file content', got %q", output.Content)
+		}
+	})
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/activities/composeflatcommit/activity.go
+++ b/internal/activities/composeflatcommit/activity.go
@@ -1,0 +1,96 @@
+/*
+Copyright © 2025 Andrew Vasilyev <me@retran.me>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package composeflatcommit provides the activity for composing commit messages using the full diff.
+package composeflatcommit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/retran/meowg1k/internal/activities/composeflat"
+	"github.com/retran/meowg1k/internal/activities/invokellm"
+	"github.com/retran/meowg1k/internal/domain/git"
+	"github.com/retran/meowg1k/internal/domain/profile"
+	"github.com/retran/meowg1k/pkg/executor"
+)
+
+// Input defines the input structure for the ComposeFlatCommit activity.
+type Input struct {
+	Profile      *profile.ResolvedProfile
+	SystemPrompt string
+	Changes      []*git.FileChange
+	Intent       string // Optional developer intent
+}
+
+// Output defines the output structure for the ComposeFlatCommit activity.
+type Output struct {
+	CommitMessage string
+}
+
+// Factory creates instances of the ComposeFlatCommit activity with injected dependencies.
+type Factory struct {
+	genericFactory *composeflat.Factory
+}
+
+// Compile-time check to ensure Factory implements ActivityFactory interface
+var _ executor.ActivityFactory[*Input, *Output] = (*Factory)(nil)
+
+// NewFactory creates a new ComposeFlatCommit activity factory with the provided content generation activity factory.
+func NewFactory(contentGenerationActivityFactory executor.ActivityFactory[*invokellm.Input, *invokellm.Output]) (*Factory, error) {
+	genericFactory, err := composeflat.NewFactory(
+		contentGenerationActivityFactory,
+		"Composing commit message",
+		"commit message",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create generic factory: %w", err)
+	}
+
+	return &Factory{
+		genericFactory: genericFactory,
+	}, nil
+}
+
+// NewActivity creates and returns the ComposeFlatCommit activity function with added progress reporting.
+func (f *Factory) NewActivity() executor.Activity[*Input, *Output] {
+	genericActivity := f.genericFactory.NewActivity()
+
+	return func(ctx context.Context, executorCtx *executor.Context, input *Input) (*Output, error) {
+		if input == nil {
+			return nil, fmt.Errorf("input cannot be nil")
+		}
+
+		// Convert input to generic format
+		genericInput := &composeflat.Input{
+			Profile:      input.Profile,
+			SystemPrompt: input.SystemPrompt,
+			Changes:      input.Changes,
+			Intent:       input.Intent,
+		}
+
+		// Execute generic activity
+		genericOutput, err := genericActivity(ctx, executorCtx, genericInput)
+		if err != nil {
+			return nil, err
+		}
+
+		// Convert output back to commit-specific format
+		return &Output{
+			CommitMessage: genericOutput.Content,
+		}, nil
+	}
+}

--- a/internal/activities/composeflatcommit/activity_test.go
+++ b/internal/activities/composeflatcommit/activity_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright © 2025 Andrew Vasilyev <me@retran.me>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package composeflatcommit_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/retran/meowg1k/internal/activities/composeflatcommit"
+	"github.com/retran/meowg1k/internal/activities/invokellm"
+	"github.com/retran/meowg1k/internal/domain/git"
+	"github.com/retran/meowg1k/internal/domain/profile"
+	"github.com/retran/meowg1k/internal/domain/provider"
+	"github.com/retran/meowg1k/pkg/executor"
+)
+
+// mockInvokeLLMFactory is a mock implementation of the invokeLLM factory for testing.
+type mockInvokeLLMFactory struct {
+	response string
+	err      error
+}
+
+func (m *mockInvokeLLMFactory) NewActivity() executor.Activity[*invokellm.Input, *invokellm.Output] {
+	return func(ctx context.Context, executorCtx *executor.Context, input *invokellm.Input) (*invokellm.Output, error) {
+		if m.err != nil {
+			return nil, m.err
+		}
+		return &invokellm.Output{
+			Content: m.response,
+		}, nil
+	}
+}
+
+func TestComposeFlatCommit_Success(t *testing.T) {
+	mockLLM := &mockInvokeLLMFactory{
+		response: "feat: add new feature\n\nAdded support for flat strategy",
+	}
+
+	factory, err := composeflatcommit.NewFactory(mockLLM)
+	if err != nil {
+		t.Fatalf("Failed to create factory: %v", err)
+	}
+
+	activity := factory.NewActivity()
+
+	testProfile := &profile.ResolvedProfile{
+		Name:            "test",
+		Provider:        provider.Gemini,
+		Model:           "test-model",
+		MaxInputTokens:  10000,
+		MaxOutputTokens: 1000,
+		Timeout:         5 * time.Minute,
+	}
+
+	changes := []*git.FileChange{
+		{
+			Filename: "test.go",
+			Change:   "+func Test() {}\n-func OldTest() {}",
+		},
+	}
+
+	input := &composeflatcommit.Input{
+		Profile:      testProfile,
+		SystemPrompt: "Generate a commit message",
+		Changes:      changes,
+		Intent:       "",
+	}
+
+	ctx := context.Background()
+	mockExec := executor.NewExecutor()
+	executorCtx := executor.NewContext("test", nil, mockExec)
+
+	output, err := activity(ctx, executorCtx, input)
+	if err != nil {
+		t.Fatalf("Activity failed: %v", err)
+	}
+
+	if output.CommitMessage != mockLLM.response {
+		t.Errorf("Expected commit message %q, got %q", mockLLM.response, output.CommitMessage)
+	}
+}
+
+func TestComposeFlatCommit_WithIntent(t *testing.T) {
+	mockLLM := &mockInvokeLLMFactory{
+		response: "feat: implement user request",
+	}
+
+	factory, err := composeflatcommit.NewFactory(mockLLM)
+	if err != nil {
+		t.Fatalf("Failed to create factory: %v", err)
+	}
+
+	activity := factory.NewActivity()
+
+	testProfile := &profile.ResolvedProfile{
+		Name:            "test",
+		Provider:        provider.Gemini,
+		Model:           "test-model",
+		MaxInputTokens:  10000,
+		MaxOutputTokens: 1000,
+		Timeout:         5 * time.Minute,
+	}
+
+	changes := []*git.FileChange{
+		{
+			Filename: "feature.go",
+			Change:   "+func NewFeature() {}",
+		},
+	}
+
+	input := &composeflatcommit.Input{
+		Profile:      testProfile,
+		SystemPrompt: "Generate a commit message",
+		Changes:      changes,
+		Intent:       "Add support for flat strategy",
+	}
+
+	ctx := context.Background()
+	mockExec := executor.NewExecutor()
+	executorCtx := executor.NewContext("test", nil, mockExec)
+
+	output, err := activity(ctx, executorCtx, input)
+	if err != nil {
+		t.Fatalf("Activity failed: %v", err)
+	}
+
+	if output.CommitMessage != mockLLM.response {
+		t.Errorf("Expected commit message %q, got %q", mockLLM.response, output.CommitMessage)
+	}
+}
+
+func TestComposeFlatCommit_DiffTooLarge(t *testing.T) {
+	mockLLM := &mockInvokeLLMFactory{
+		response: "feat: add feature",
+	}
+
+	factory, err := composeflatcommit.NewFactory(mockLLM)
+	if err != nil {
+		t.Fatalf("Failed to create factory: %v", err)
+	}
+
+	activity := factory.NewActivity()
+
+	testProfile := &profile.ResolvedProfile{
+		Name:            "test",
+		Provider:        provider.Gemini,
+		Model:           "test-model",
+		MaxInputTokens:  100, // Very small limit
+		MaxOutputTokens: 1000,
+		Timeout:         5 * time.Minute,
+	}
+
+	// Create a large diff that exceeds the token limit
+	largeChange := strings.Repeat("a", 500) // ~125 tokens (500 chars / 4)
+	changes := []*git.FileChange{
+		{
+			Filename: "large.go",
+			Change:   largeChange,
+		},
+	}
+
+	input := &composeflatcommit.Input{
+		Profile:      testProfile,
+		SystemPrompt: "Generate a commit message",
+		Changes:      changes,
+		Intent:       "",
+	}
+
+	ctx := context.Background()
+	mockExec := executor.NewExecutor()
+	executorCtx := executor.NewContext("test", nil, mockExec)
+
+	_, err = activity(ctx, executorCtx, input)
+	if err == nil {
+		t.Fatal("Expected error for oversized diff, got nil")
+	}
+
+	expectedErrSubstring := "diff is too large for 'flat' strategy"
+	if !strings.Contains(err.Error(), expectedErrSubstring) {
+		t.Errorf("Expected error to contain %q, got %q", expectedErrSubstring, err.Error())
+	}
+}
+
+func TestComposeFlatCommit_NilFactory(t *testing.T) {
+	_, err := composeflatcommit.NewFactory(nil)
+	if err == nil {
+		t.Fatal("Expected error for nil factory, got nil")
+	}
+}
+
+func TestComposeFlatCommit_NilInput(t *testing.T) {
+	mockLLM := &mockInvokeLLMFactory{
+		response: "feat: add feature",
+	}
+
+	factory, err := composeflatcommit.NewFactory(mockLLM)
+	if err != nil {
+		t.Fatalf("Failed to create factory: %v", err)
+	}
+
+	activity := factory.NewActivity()
+
+	ctx := context.Background()
+	mockExec := executor.NewExecutor()
+	executorCtx := executor.NewContext("test", nil, mockExec)
+
+	_, err = activity(ctx, executorCtx, nil)
+	if err == nil {
+		t.Fatal("Expected error for nil input, got nil")
+	}
+}
+
+func TestComposeFlatCommit_MultipleFiles(t *testing.T) {
+	mockLLM := &mockInvokeLLMFactory{
+		response: "feat: update multiple files",
+	}
+
+	factory, err := composeflatcommit.NewFactory(mockLLM)
+	if err != nil {
+		t.Fatalf("Failed to create factory: %v", err)
+	}
+
+	activity := factory.NewActivity()
+
+	testProfile := &profile.ResolvedProfile{
+		Name:            "test",
+		Provider:        provider.Gemini,
+		Model:           "test-model",
+		MaxInputTokens:  10000,
+		MaxOutputTokens: 1000,
+		Timeout:         5 * time.Minute,
+	}
+
+	changes := []*git.FileChange{
+		{
+			Filename: "file1.go",
+			Change:   "+func File1() {}",
+		},
+		{
+			Filename: "file2.go",
+			Change:   "+func File2() {}",
+		},
+		{
+			Filename: "file3.go",
+			Change:   "+func File3() {}",
+		},
+	}
+
+	input := &composeflatcommit.Input{
+		Profile:      testProfile,
+		SystemPrompt: "Generate a commit message",
+		Changes:      changes,
+		Intent:       "",
+	}
+
+	ctx := context.Background()
+	mockExec := executor.NewExecutor()
+	executorCtx := executor.NewContext("test", nil, mockExec)
+
+	output, err := activity(ctx, executorCtx, input)
+	if err != nil {
+		t.Fatalf("Activity failed: %v", err)
+	}
+
+	if output.CommitMessage != mockLLM.response {
+		t.Errorf("Expected commit message %q, got %q", mockLLM.response, output.CommitMessage)
+	}
+}

--- a/internal/activities/composeflatpr/activity.go
+++ b/internal/activities/composeflatpr/activity.go
@@ -1,0 +1,96 @@
+/*
+Copyright © 2025 Andrew Vasilyev <me@retran.me>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package composeflatpr provides the activity for composing PR descriptions using the full diff.
+package composeflatpr
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/retran/meowg1k/internal/activities/composeflat"
+	"github.com/retran/meowg1k/internal/activities/invokellm"
+	"github.com/retran/meowg1k/internal/domain/git"
+	"github.com/retran/meowg1k/internal/domain/profile"
+	"github.com/retran/meowg1k/pkg/executor"
+)
+
+// Input defines the input structure for the ComposeFlatPR activity.
+type Input struct {
+	Profile      *profile.ResolvedProfile
+	SystemPrompt string
+	Changes      []*git.FileChange
+	Intent       string // Optional developer intent
+}
+
+// Output defines the output structure for the ComposeFlatPR activity.
+type Output struct {
+	Description string
+}
+
+// Factory creates instances of the ComposeFlatPR activity with injected dependencies.
+type Factory struct {
+	genericFactory *composeflat.Factory
+}
+
+// Compile-time check to ensure Factory implements ActivityFactory interface
+var _ executor.ActivityFactory[*Input, *Output] = (*Factory)(nil)
+
+// NewFactory creates a new ComposeFlatPR activity factory with the provided content generation activity factory.
+func NewFactory(contentGenerationActivityFactory executor.ActivityFactory[*invokellm.Input, *invokellm.Output]) (*Factory, error) {
+	genericFactory, err := composeflat.NewFactory(
+		contentGenerationActivityFactory,
+		"Composing PR description",
+		"PR description",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create generic factory: %w", err)
+	}
+
+	return &Factory{
+		genericFactory: genericFactory,
+	}, nil
+}
+
+// NewActivity creates and returns the ComposeFlatPR activity function with added progress reporting.
+func (f *Factory) NewActivity() executor.Activity[*Input, *Output] {
+	genericActivity := f.genericFactory.NewActivity()
+
+	return func(ctx context.Context, executorCtx *executor.Context, input *Input) (*Output, error) {
+		if input == nil {
+			return nil, fmt.Errorf("input cannot be nil")
+		}
+
+		// Convert input to generic format
+		genericInput := &composeflat.Input{
+			Profile:      input.Profile,
+			SystemPrompt: input.SystemPrompt,
+			Changes:      input.Changes,
+			Intent:       input.Intent,
+		}
+
+		// Execute generic activity
+		genericOutput, err := genericActivity(ctx, executorCtx, genericInput)
+		if err != nil {
+			return nil, err
+		}
+
+		// Convert output back to PR-specific format
+		return &Output{
+			Description: genericOutput.Content,
+		}, nil
+	}
+}

--- a/internal/activities/composeflatpr/activity_test.go
+++ b/internal/activities/composeflatpr/activity_test.go
@@ -1,0 +1,326 @@
+/*
+Copyright © 2025 Andrew Vasilyev <me@retran.me>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package composeflatpr_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/retran/meowg1k/internal/activities/composeflatpr"
+	"github.com/retran/meowg1k/internal/activities/invokellm"
+	"github.com/retran/meowg1k/internal/domain/git"
+	"github.com/retran/meowg1k/internal/domain/profile"
+	"github.com/retran/meowg1k/internal/domain/provider"
+	"github.com/retran/meowg1k/pkg/executor"
+)
+
+// mockInvokeLLMFactory is a mock implementation of the invokeLLM factory for testing.
+type mockInvokeLLMFactory struct {
+	response string
+	err      error
+}
+
+func (m *mockInvokeLLMFactory) NewActivity() executor.Activity[*invokellm.Input, *invokellm.Output] {
+	return func(ctx context.Context, executorCtx *executor.Context, input *invokellm.Input) (*invokellm.Output, error) {
+		if m.err != nil {
+			return nil, m.err
+		}
+		return &invokellm.Output{
+			Content: m.response,
+		}, nil
+	}
+}
+
+func TestComposeFlatPR_Success(t *testing.T) {
+	mockLLM := &mockInvokeLLMFactory{
+		response: "# Add new feature\n\n## Summary\nAdded support for flat strategy in PR descriptions",
+	}
+
+	factory, err := composeflatpr.NewFactory(mockLLM)
+	if err != nil {
+		t.Fatalf("Failed to create factory: %v", err)
+	}
+
+	activity := factory.NewActivity()
+
+	testProfile := &profile.ResolvedProfile{
+		Name:            "test",
+		Provider:        provider.Gemini,
+		Model:           "test-model",
+		MaxInputTokens:  10000,
+		MaxOutputTokens: 1000,
+		Timeout:         5 * time.Minute,
+	}
+
+	changes := []*git.FileChange{
+		{
+			Filename: "test.go",
+			Change:   "+func Test() {}\n-func OldTest() {}",
+		},
+	}
+
+	input := &composeflatpr.Input{
+		Profile:      testProfile,
+		SystemPrompt: "Generate a PR description",
+		Changes:      changes,
+		Intent:       "",
+	}
+
+	ctx := context.Background()
+	mockExec := executor.NewExecutor()
+	executorCtx := executor.NewContext("test", nil, mockExec)
+
+	output, err := activity(ctx, executorCtx, input)
+	if err != nil {
+		t.Fatalf("Activity failed: %v", err)
+	}
+
+	if output.Description != mockLLM.response {
+		t.Errorf("Expected description %q, got %q", mockLLM.response, output.Description)
+	}
+}
+
+func TestComposeFlatPR_WithIntent(t *testing.T) {
+	mockLLM := &mockInvokeLLMFactory{
+		response: "# Implement user request\n\n## Summary\nImplemented flat strategy as requested",
+	}
+
+	factory, err := composeflatpr.NewFactory(mockLLM)
+	if err != nil {
+		t.Fatalf("Failed to create factory: %v", err)
+	}
+
+	activity := factory.NewActivity()
+
+	testProfile := &profile.ResolvedProfile{
+		Name:            "test",
+		Provider:        provider.Gemini,
+		Model:           "test-model",
+		MaxInputTokens:  10000,
+		MaxOutputTokens: 1000,
+		Timeout:         5 * time.Minute,
+	}
+
+	changes := []*git.FileChange{
+		{
+			Filename: "feature.go",
+			Change:   "+func NewFeature() {}",
+		},
+	}
+
+	input := &composeflatpr.Input{
+		Profile:      testProfile,
+		SystemPrompt: "Generate a PR description",
+		Changes:      changes,
+		Intent:       "Add support for flat strategy in PR descriptions",
+	}
+
+	ctx := context.Background()
+	mockExec := executor.NewExecutor()
+	executorCtx := executor.NewContext("test", nil, mockExec)
+
+	output, err := activity(ctx, executorCtx, input)
+	if err != nil {
+		t.Fatalf("Activity failed: %v", err)
+	}
+
+	if output.Description != mockLLM.response {
+		t.Errorf("Expected description %q, got %q", mockLLM.response, output.Description)
+	}
+}
+
+func TestComposeFlatPR_DiffTooLarge(t *testing.T) {
+	mockLLM := &mockInvokeLLMFactory{
+		response: "# Add feature",
+	}
+
+	factory, err := composeflatpr.NewFactory(mockLLM)
+	if err != nil {
+		t.Fatalf("Failed to create factory: %v", err)
+	}
+
+	activity := factory.NewActivity()
+
+	testProfile := &profile.ResolvedProfile{
+		Name:            "test",
+		Provider:        provider.Gemini,
+		Model:           "test-model",
+		MaxInputTokens:  100, // Very small limit
+		MaxOutputTokens: 1000,
+		Timeout:         5 * time.Minute,
+	}
+
+	// Create a large diff that exceeds the token limit
+	largeChange := strings.Repeat("a", 500) // ~125 tokens (500 chars / 4)
+	changes := []*git.FileChange{
+		{
+			Filename: "large.go",
+			Change:   largeChange,
+		},
+	}
+
+	input := &composeflatpr.Input{
+		Profile:      testProfile,
+		SystemPrompt: "Generate a PR description",
+		Changes:      changes,
+		Intent:       "",
+	}
+
+	ctx := context.Background()
+	mockExec := executor.NewExecutor()
+	executorCtx := executor.NewContext("test", nil, mockExec)
+
+	_, err = activity(ctx, executorCtx, input)
+	if err == nil {
+		t.Fatal("Expected error for oversized diff, got nil")
+	}
+
+	expectedErrSubstring := "diff is too large for 'flat' strategy"
+	if !strings.Contains(err.Error(), expectedErrSubstring) {
+		t.Errorf("Expected error to contain %q, got %q", expectedErrSubstring, err.Error())
+	}
+}
+
+func TestComposeFlatPR_NilFactory(t *testing.T) {
+	_, err := composeflatpr.NewFactory(nil)
+	if err == nil {
+		t.Fatal("Expected error for nil factory, got nil")
+	}
+}
+
+func TestComposeFlatPR_NilInput(t *testing.T) {
+	mockLLM := &mockInvokeLLMFactory{
+		response: "# Add feature",
+	}
+
+	factory, err := composeflatpr.NewFactory(mockLLM)
+	if err != nil {
+		t.Fatalf("Failed to create factory: %v", err)
+	}
+
+	activity := factory.NewActivity()
+
+	ctx := context.Background()
+	mockExec := executor.NewExecutor()
+	executorCtx := executor.NewContext("test", nil, mockExec)
+
+	_, err = activity(ctx, executorCtx, nil)
+	if err == nil {
+		t.Fatal("Expected error for nil input, got nil")
+	}
+}
+
+func TestComposeFlatPR_MultipleFiles(t *testing.T) {
+	mockLLM := &mockInvokeLLMFactory{
+		response: "# Update multiple files\n\n## Summary\nUpdated three files to implement new feature",
+	}
+
+	factory, err := composeflatpr.NewFactory(mockLLM)
+	if err != nil {
+		t.Fatalf("Failed to create factory: %v", err)
+	}
+
+	activity := factory.NewActivity()
+
+	testProfile := &profile.ResolvedProfile{
+		Name:            "test",
+		Provider:        provider.Gemini,
+		Model:           "test-model",
+		MaxInputTokens:  10000,
+		MaxOutputTokens: 1000,
+		Timeout:         5 * time.Minute,
+	}
+
+	changes := []*git.FileChange{
+		{
+			Filename: "file1.go",
+			Change:   "+func File1() {}",
+		},
+		{
+			Filename: "file2.go",
+			Change:   "+func File2() {}",
+		},
+		{
+			Filename: "file3.go",
+			Change:   "+func File3() {}",
+		},
+	}
+
+	input := &composeflatpr.Input{
+		Profile:      testProfile,
+		SystemPrompt: "Generate a PR description",
+		Changes:      changes,
+		Intent:       "",
+	}
+
+	ctx := context.Background()
+	mockExec := executor.NewExecutor()
+	executorCtx := executor.NewContext("test", nil, mockExec)
+
+	output, err := activity(ctx, executorCtx, input)
+	if err != nil {
+		t.Fatalf("Activity failed: %v", err)
+	}
+
+	if output.Description != mockLLM.response {
+		t.Errorf("Expected description %q, got %q", mockLLM.response, output.Description)
+	}
+}
+
+func TestComposeFlatPR_EmptyChanges(t *testing.T) {
+	mockLLM := &mockInvokeLLMFactory{
+		response: "# No changes",
+	}
+
+	factory, err := composeflatpr.NewFactory(mockLLM)
+	if err != nil {
+		t.Fatalf("Failed to create factory: %v", err)
+	}
+
+	activity := factory.NewActivity()
+
+	testProfile := &profile.ResolvedProfile{
+		Name:            "test",
+		Provider:        provider.Gemini,
+		Model:           "test-model",
+		MaxInputTokens:  10000,
+		MaxOutputTokens: 1000,
+		Timeout:         5 * time.Minute,
+	}
+
+	input := &composeflatpr.Input{
+		Profile:      testProfile,
+		SystemPrompt: "Generate a PR description",
+		Changes:      []*git.FileChange{},
+		Intent:       "",
+	}
+
+	ctx := context.Background()
+	mockExec := executor.NewExecutor()
+	executorCtx := executor.NewContext("test", nil, mockExec)
+
+	output, err := activity(ctx, executorCtx, input)
+	if err != nil {
+		t.Fatalf("Activity failed: %v", err)
+	}
+
+	if output.Description != mockLLM.response {
+		t.Errorf("Expected description %q, got %q", mockLLM.response, output.Description)
+	}
+}

--- a/internal/app/flows.go
+++ b/internal/app/flows.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/retran/meowg1k/internal/activities/applyfilters"
 	"github.com/retran/meowg1k/internal/activities/composecommit"
+	"github.com/retran/meowg1k/internal/activities/composeflatcommit"
+	"github.com/retran/meowg1k/internal/activities/composeflatpr"
 	"github.com/retran/meowg1k/internal/activities/composepr"
 	"github.com/retran/meowg1k/internal/activities/fetchallbranchdiffs"
 	"github.com/retran/meowg1k/internal/activities/fetchalldiffs"
@@ -144,6 +146,11 @@ func (c *Container) CreateCommitFlow() (executor.Flow, error) {
 		return nil, fmt.Errorf("failed to create compose commit factory: %w", err)
 	}
 
+	composeFlatCommitFactory, err := composeflatcommit.NewFactory(invokeLLMFactory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create compose flat commit factory: %w", err)
+	}
+
 	flowFactory, err := commitFlow.NewFactory(
 		listStagedActivityFactory,
 		listBranchFilesActivityFactory,
@@ -152,6 +159,7 @@ func (c *Container) CreateCommitFlow() (executor.Flow, error) {
 		fetchAllBranchDiffsFactory,
 		summarizeAllFactory,
 		composeCommitFactory,
+		composeFlatCommitFactory,
 		commitConfigService,
 		c.CommandService,
 		c.OutputService,
@@ -300,12 +308,18 @@ func (c *Container) CreatePullRequestFlow() (executor.Flow, error) {
 		return nil, fmt.Errorf("failed to create compose pullrequest factory: %w", err)
 	}
 
+	composeFlatPRFactory, err := composeflatpr.NewFactory(invokeLLMFactory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create compose flat pullrequest factory: %w", err)
+	}
+
 	flowFactory, err := pr.NewFactory(
 		listBranchFilesActivityFactory,
 		applyFiltersActivityFactory,
 		fetchAllBranchDiffsFactory,
 		summarizeAllFactory,
 		composePRFactory,
+		composeFlatPRFactory,
 		prConfigService,
 		c.CommandService,
 		c.OutputService,

--- a/internal/core/commit/service.go
+++ b/internal/core/commit/service.go
@@ -68,10 +68,17 @@ func (s *Service) Get() (*commit2.ResolvedConfig, error) {
 
 	var profileName string
 	var systemPrompt string
+	var strategy string
 
 	if cfg.Commit != nil {
 		profileName = cfg.Commit.Profile
 		systemPrompt = cfg.Commit.SystemPrompt
+		strategy = cfg.Commit.Strategy
+	}
+
+	// Default to "summarize" if strategy is not specified
+	if strategy == "" {
+		strategy = "summarize"
 	}
 
 	resolvedProfile, err := s.profileResolver.Get(profile.Profile(profileName))
@@ -85,6 +92,7 @@ func (s *Service) Get() (*commit2.ResolvedConfig, error) {
 
 	return &commit2.ResolvedConfig{
 		Profile:      resolvedProfile,
+		Strategy:     strategy,
 		SystemPrompt: systemPrompt,
 	}, nil
 }

--- a/internal/core/model/registry.go
+++ b/internal/core/model/registry.go
@@ -236,70 +236,166 @@ var models = map[string]model2.ModelInfo{
 	},
 
 	// Anthropic models (provider: openrouter)
-	"anthropic/claude-sonnet-4": {
-		Provider:         "openrouter",
-		MaxContextTokens: 1000000,
-		MaxOutputTokens:  64000,
-		TokenizerType:    model2.TokenizerCL100K,
-		Description:      "Anthropic Claude Sonnet 4 - high-performance model with 1M context window",
-	},
-	"anthropic/claude-3.7-sonnet": {
+	"anthropic/claude-sonnet-4-5": {
 		Provider:         "openrouter",
 		MaxContextTokens: 200000,
 		MaxOutputTokens:  64000,
 		TokenizerType:    model2.TokenizerCL100K,
-		Description:      "Anthropic Claude 3.7 Sonnet - high-performance with early extended thinking",
+		Description:      "Anthropic Claude Sonnet 4.5 (via OpenRouter) - best for complex agents and coding",
 	},
-	"anthropic/claude-3.5-haiku": {
-		Provider:         "openrouter",
-		MaxContextTokens: 200000,
-		MaxOutputTokens:  8192,
-		TokenizerType:    model2.TokenizerCL100K,
-		Description:      "Anthropic Claude 3.5 Haiku - fastest model for near-instant responsiveness",
-	},
-	"anthropic/claude-opus-4.1": {
+	"anthropic/claude-opus-4-1": {
 		Provider:         "openrouter",
 		MaxContextTokens: 200000,
 		MaxOutputTokens:  32000,
 		TokenizerType:    model2.TokenizerCL100K,
-		Description:      "Anthropic Claude Opus 4.1 - most capable and intelligent model",
+		Description:      "Anthropic Claude Opus 4.1 (via OpenRouter) - exceptional for specialized complex tasks",
+	},
+	"anthropic/claude-sonnet-4": {
+		Provider:         "openrouter",
+		MaxContextTokens: 200000,
+		MaxOutputTokens:  64000,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude Sonnet 4 (via OpenRouter) - high-performance model",
+	},
+	"anthropic/claude-opus-4": {
+		Provider:         "openrouter",
+		MaxContextTokens: 200000,
+		MaxOutputTokens:  32000,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude Opus 4 (via OpenRouter) - previous flagship model",
+	},
+	"anthropic/claude-3-7-sonnet": {
+		Provider:         "openrouter",
+		MaxContextTokens: 200000,
+		MaxOutputTokens:  64000,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude 3.7 Sonnet (via OpenRouter) - high-performance with early extended thinking",
+	},
+	"anthropic/claude-3-5-haiku": {
+		Provider:         "openrouter",
+		MaxContextTokens: 200000,
+		MaxOutputTokens:  8192,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude 3.5 Haiku (via OpenRouter) - fastest model",
 	},
 
 	// Anthropic models (direct provider: anthropic)
+	// Claude 4.5 and Claude 4 - Latest generation (2025)
+	"claude-sonnet-4-5-20250929": {
+		Provider:         "anthropic",
+		MaxContextTokens: 200000, // 1M beta available with context-1m-2025-08-07 header
+		MaxOutputTokens:  64000,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude Sonnet 4.5 (Sep 2025) - best model for complex agents and coding with highest intelligence",
+	},
+	"claude-sonnet-4-5": {
+		Provider:         "anthropic",
+		MaxContextTokens: 200000,
+		MaxOutputTokens:  64000,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude Sonnet 4.5 (alias) - latest snapshot",
+	},
+	"claude-opus-4-1-20250805": {
+		Provider:         "anthropic",
+		MaxContextTokens: 200000,
+		MaxOutputTokens:  32000,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude Opus 4.1 (Aug 2025) - exceptional model for specialized complex tasks",
+	},
 	"claude-opus-4-1": {
 		Provider:         "anthropic",
 		MaxContextTokens: 200000,
 		MaxOutputTokens:  32000,
 		TokenizerType:    model2.TokenizerCL100K,
-		Description:      "Anthropic Claude Opus 4.1 - most capable and intelligent model",
+		Description:      "Anthropic Claude Opus 4.1 (alias) - latest snapshot",
+	},
+	"claude-sonnet-4-20250514": {
+		Provider:         "anthropic",
+		MaxContextTokens: 200000, // 1M beta available with context-1m-2025-08-07 header
+		MaxOutputTokens:  64000,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude Sonnet 4 (May 2025) - high-performance model",
+	},
+	"claude-sonnet-4-0": {
+		Provider:         "anthropic",
+		MaxContextTokens: 200000,
+		MaxOutputTokens:  64000,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude Sonnet 4 (alias) - latest snapshot",
 	},
 	"claude-sonnet-4": {
 		Provider:         "anthropic",
-		MaxContextTokens: 1000000,
+		MaxContextTokens: 1000000, // Extended thinking with 1M context
 		MaxOutputTokens:  64000,
 		TokenizerType:    model2.TokenizerCL100K,
-		Description:      "Anthropic Claude Sonnet 4 - high-performance model with 1M context window",
+		Description:      "Anthropic Claude Sonnet 4 (alias) - latest snapshot with extended context",
 	},
+	"claude-opus-4-20250514": {
+		Provider:         "anthropic",
+		MaxContextTokens: 200000,
+		MaxOutputTokens:  32000,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude Opus 4 (May 2025) - previous flagship model",
+	},
+	"claude-opus-4-0": {
+		Provider:         "anthropic",
+		MaxContextTokens: 200000,
+		MaxOutputTokens:  32000,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude Opus 4 (alias) - latest snapshot",
+	},
+	"claude-3-7-sonnet-20250219": {
+		Provider:         "anthropic",
+		MaxContextTokens: 200000,
+		MaxOutputTokens:  64000,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude Sonnet 3.7 (Feb 2025) - high-performance with early extended thinking",
+	},
+	"claude-3-7-sonnet-latest": {
+		Provider:         "anthropic",
+		MaxContextTokens: 200000,
+		MaxOutputTokens:  64000,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude Sonnet 3.7 (alias) - latest snapshot",
+	},
+
+	// Claude 3.5 generation (2024)
 	"claude-3-5-haiku-20241022": {
 		Provider:         "anthropic",
 		MaxContextTokens: 200000,
 		MaxOutputTokens:  8192,
 		TokenizerType:    model2.TokenizerCL100K,
-		Description:      "Anthropic Claude 3.5 Haiku - fastest model for near-instant responsiveness",
+		Description:      "Anthropic Claude 3.5 Haiku (Oct 2024) - fastest model for near-instant responsiveness",
+	},
+	"claude-3-5-haiku-latest": {
+		Provider:         "anthropic",
+		MaxContextTokens: 200000,
+		MaxOutputTokens:  8192,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude 3.5 Haiku (alias) - latest snapshot",
 	},
 	"claude-3-5-sonnet-20241022": {
 		Provider:         "anthropic",
 		MaxContextTokens: 200000,
 		MaxOutputTokens:  8192,
 		TokenizerType:    model2.TokenizerCL100K,
-		Description:      "Anthropic Claude 3.5 Sonnet - balanced performance and speed",
+		Description:      "Anthropic Claude 3.5 Sonnet (Oct 2024) - DEPRECATED - balanced performance and speed",
+	},
+
+	// Claude 3 generation (legacy, 2024)
+	"claude-3-haiku-20240307": {
+		Provider:         "anthropic",
+		MaxContextTokens: 200000,
+		MaxOutputTokens:  4096,
+		TokenizerType:    model2.TokenizerCL100K,
+		Description:      "Anthropic Claude 3 Haiku (Mar 2024) - fast and compact model",
 	},
 	"claude-3-opus-20240229": {
 		Provider:         "anthropic",
 		MaxContextTokens: 200000,
 		MaxOutputTokens:  4096,
 		TokenizerType:    model2.TokenizerCL100K,
-		Description:      "Anthropic Claude 3 Opus - most capable model for complex tasks",
+		Description:      "Anthropic Claude 3 Opus (Feb 2024) - DEPRECATED - most capable model for complex tasks",
 	},
 
 	// Google models (provider: openrouter)

--- a/internal/core/pullrequest/service.go
+++ b/internal/core/pullrequest/service.go
@@ -60,10 +60,17 @@ func (s *Service) Get() (*pullrequest2.ResolvedConfig, error) {
 
 	var profileName string
 	var systemPrompt string
+	var strategy string
 
 	if config.PullRequest != nil {
 		profileName = config.PullRequest.Profile
 		systemPrompt = config.PullRequest.SystemPrompt
+		strategy = config.PullRequest.Strategy
+	}
+
+	// Default to "summarize" if strategy is not specified
+	if strategy == "" {
+		strategy = "summarize"
 	}
 
 	resolvedProfile, err := s.profileResolver.Get(profile.Profile(profileName))
@@ -77,6 +84,7 @@ func (s *Service) Get() (*pullrequest2.ResolvedConfig, error) {
 
 	return &pullrequest2.ResolvedConfig{
 		Profile:      resolvedProfile,
+		Strategy:     strategy,
 		SystemPrompt: systemPrompt,
 	}, nil
 }

--- a/internal/domain/commit/types.go
+++ b/internal/domain/commit/types.go
@@ -23,5 +23,6 @@ import (
 // ResolvedConfig represents the resolved configuration for generating a commit message.
 type ResolvedConfig struct {
 	Profile      *profile.ResolvedProfile
+	Strategy     string // "summarize" or "flat"
 	SystemPrompt string
 }

--- a/internal/domain/config/types.go
+++ b/internal/domain/config/types.go
@@ -219,6 +219,11 @@ type CommandConfig struct {
 	// Profile references a profile defined in the profiles section
 	Profile string `yaml:"profile" mapstructure:"profile"`
 
+	// Strategy determines how changes are processed:
+	// - "summarize" (default): uses Map-Reduce approach to summarize each file then compose the final message
+	// - "flat": sends the entire diff directly to the model without summarization
+	Strategy string `yaml:"strategy" mapstructure:"strategy"`
+
 	// SystemPrompt sets the system prompt for the command
 	SystemPrompt string `yaml:"systemPrompt" mapstructure:"systemPrompt"`
 }

--- a/internal/domain/pullrequest/types.go
+++ b/internal/domain/pullrequest/types.go
@@ -23,5 +23,6 @@ import (
 // ResolvedConfig represents the resolved configuration for generating a PR description.
 type ResolvedConfig struct {
 	Profile      *profile.ResolvedProfile
+	Strategy     string // "summarize" or "flat"
 	SystemPrompt string
 }

--- a/internal/flows/commit/flow.go
+++ b/internal/flows/commit/flow.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/retran/meowg1k/internal/activities/applyfilters"
 	"github.com/retran/meowg1k/internal/activities/composecommit"
+	"github.com/retran/meowg1k/internal/activities/composeflatcommit"
 	"github.com/retran/meowg1k/internal/activities/fetchallbranchdiffs"
 	"github.com/retran/meowg1k/internal/activities/fetchalldiffs"
 	"github.com/retran/meowg1k/internal/activities/listbranchfiles"
@@ -55,6 +56,7 @@ type Factory struct {
 	fetchAllBranchDiffsFactory executor.ActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]
 	summarizeAllFactory        executor.ActivityFactory[*summarizeall.Input, *summarizeall.Output]
 	composeCommitFactory       executor.ActivityFactory[*composecommit.Input, *composecommit.Output]
+	composeFlatCommitFactory   executor.ActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]
 	commitConfigProvider       CommitConfigProvider
 	commandParametersReader    CommandParametersReader
 	outputWriter               ports.OutputWriter
@@ -69,6 +71,7 @@ func NewFactory(
 	fetchAllBranchDiffsFactory executor.ActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output],
 	summarizeAllFactory executor.ActivityFactory[*summarizeall.Input, *summarizeall.Output],
 	composeCommitFactory executor.ActivityFactory[*composecommit.Input, *composecommit.Output],
+	composeFlatCommitFactory executor.ActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output],
 	commitConfigProvider CommitConfigProvider,
 	commandParametersReader CommandParametersReader,
 	outputWriter ports.OutputWriter,
@@ -101,6 +104,10 @@ func NewFactory(
 		return nil, fmt.Errorf("composeCommitFactory is nil")
 	}
 
+	if composeFlatCommitFactory == nil {
+		return nil, fmt.Errorf("composeFlatCommitFactory is nil")
+	}
+
 	if commitConfigProvider == nil {
 		return nil, fmt.Errorf("commitConfigProvider is nil")
 	}
@@ -121,6 +128,7 @@ func NewFactory(
 		fetchAllBranchDiffsFactory: fetchAllBranchDiffsFactory,
 		summarizeAllFactory:        summarizeAllFactory,
 		composeCommitFactory:       composeCommitFactory,
+		composeFlatCommitFactory:   composeFlatCommitFactory,
 		commitConfigProvider:       commitConfigProvider,
 		commandParametersReader:    commandParametersReader,
 		outputWriter:               outputWriter,
@@ -255,25 +263,7 @@ func (f *Factory) NewFlow() executor.Flow {
 			changes = append(changes, fetchAllDiffsOutput.Changes...)
 		}
 
-		// Phase 4: Summarize changes for all files
-		summarizeAll := f.summarizeAllFactory.NewActivity()
-		summarizeAllFuture := executor.ExecuteActivity(
-			flowCtx.GetExecutor(),
-			ctx,
-			flowCtx,
-			"SummarizeAll",
-			summarizeAll,
-			&summarizeall.Input{
-				Changes: changes,
-			},
-		)
-
-		summarizeAllOutput, err := summarizeAllFuture.Get(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to summarize changes: %w", err)
-		}
-
-		// Phase 5: Compose commit message
+		// Get configuration
 		cfg, err := f.commitConfigProvider.Get()
 		if err != nil {
 			return fmt.Errorf("failed to resolve commit configuration: %w", err)
@@ -293,29 +283,77 @@ func (f *Factory) NewFlow() executor.Flow {
 			intent = stdin
 		}
 
-		composeCommit := f.composeCommitFactory.NewActivity()
-		commitFuture := executor.ExecuteActivity(
-			flowCtx.GetExecutor(),
-			ctx,
-			flowCtx,
-			"ComposeCommit",
-			composeCommit,
-			&composecommit.Input{
-				Profile:      cfg.Profile,
-				SystemPrompt: cfg.SystemPrompt,
-				Summaries:    summarizeAllOutput.Summaries,
-				Intent:       intent,
-			},
-		)
+		var commitMessage string
 
-		commitResult, err := commitFuture.Get(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to compose commit message: %w", err)
+		// Phase 4 & 5: Compose commit message based on strategy
+		if cfg.Strategy == "flat" {
+			// Flat strategy: send full diff directly to LLM
+			composeFlatCommit := f.composeFlatCommitFactory.NewActivity()
+			flatCommitFuture := executor.ExecuteActivity(
+				flowCtx.GetExecutor(),
+				ctx,
+				flowCtx,
+				"ComposeFlatCommit",
+				composeFlatCommit,
+				&composeflatcommit.Input{
+					Profile:      cfg.Profile,
+					SystemPrompt: cfg.SystemPrompt,
+					Changes:      changes,
+					Intent:       intent,
+				},
+			)
+
+			flatCommitResult, err := flatCommitFuture.Get(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to compose commit message using flat strategy: %w", err)
+			}
+
+			commitMessage = flatCommitResult.CommitMessage
+		} else {
+			// Summarize strategy (default): use map-reduce approach
+			summarizeAll := f.summarizeAllFactory.NewActivity()
+			summarizeAllFuture := executor.ExecuteActivity(
+				flowCtx.GetExecutor(),
+				ctx,
+				flowCtx,
+				"SummarizeAll",
+				summarizeAll,
+				&summarizeall.Input{
+					Changes: changes,
+				},
+			)
+
+			summarizeAllOutput, err := summarizeAllFuture.Get(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to summarize changes: %w", err)
+			}
+
+			composeCommit := f.composeCommitFactory.NewActivity()
+			commitFuture := executor.ExecuteActivity(
+				flowCtx.GetExecutor(),
+				ctx,
+				flowCtx,
+				"ComposeCommit",
+				composeCommit,
+				&composecommit.Input{
+					Profile:      cfg.Profile,
+					SystemPrompt: cfg.SystemPrompt,
+					Summaries:    summarizeAllOutput.Summaries,
+					Intent:       intent,
+				},
+			)
+
+			commitResult, err := commitFuture.Get(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to compose commit message: %w", err)
+			}
+
+			commitMessage = commitResult.CommitMessage
 		}
 
 		flowCtx.SendCompleted("")
 
-		if err := f.outputWriter.PrintLine(commitResult.CommitMessage); err != nil {
+		if err := f.outputWriter.PrintLine(commitMessage); err != nil {
 			return fmt.Errorf("failed to print commit message: %w", err)
 		}
 

--- a/internal/flows/commit/flow_test.go
+++ b/internal/flows/commit/flow_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/retran/meowg1k/internal/activities/applyfilters"
 	"github.com/retran/meowg1k/internal/activities/composecommit"
+	"github.com/retran/meowg1k/internal/activities/composeflatcommit"
 	"github.com/retran/meowg1k/internal/activities/fetchallbranchdiffs"
 	"github.com/retran/meowg1k/internal/activities/fetchalldiffs"
 	"github.com/retran/meowg1k/internal/activities/listbranchfiles"
@@ -103,6 +104,7 @@ func TestNewFactory(t *testing.T) {
 		fetchAllBranchDiffsFactory executor.ActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]
 		summarizeAllFactory        executor.ActivityFactory[*summarizeall.Input, *summarizeall.Output]
 		composeCommitFactory       executor.ActivityFactory[*composecommit.Input, *composecommit.Output]
+		composeFlatCommitFactory   executor.ActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]
 		commitConfigProvider       CommitConfigProvider
 		commandParametersReader    CommandParametersReader
 		outputWriter               ports.OutputWriter
@@ -118,6 +120,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composeCommitFactory:       &mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+			composeFlatCommitFactory:   &mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 			commitConfigProvider:       &mockCommitConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -133,6 +136,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composeCommitFactory:       &mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+			composeFlatCommitFactory:   &mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 			commitConfigProvider:       &mockCommitConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -148,6 +152,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composeCommitFactory:       &mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+			composeFlatCommitFactory:   &mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 			commitConfigProvider:       &mockCommitConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -163,6 +168,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composeCommitFactory:       &mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+			composeFlatCommitFactory:   &mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 			commitConfigProvider:       &mockCommitConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -178,6 +184,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: nil,
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composeCommitFactory:       &mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+			composeFlatCommitFactory:   &mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 			commitConfigProvider:       &mockCommitConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -193,6 +200,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        nil,
 			composeCommitFactory:       &mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+			composeFlatCommitFactory:   &mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 			commitConfigProvider:       &mockCommitConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -208,11 +216,28 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composeCommitFactory:       nil,
+			composeFlatCommitFactory:   &mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 			commitConfigProvider:       &mockCommitConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
 			wantErr:                    true,
 			expectedErrMsg:             "composeCommitFactory is nil",
+		},
+		{
+			name:                       "nil composeFlatCommitFactory",
+			listStagedFactory:          &mockActivityFactory[*liststaged.Input, *liststaged.Output]{},
+			listBranchFilesFactory:     &mockActivityFactory[*listbranchfiles.Input, *listbranchfiles.Output]{},
+			applyFiltersFactory:        &mockActivityFactory[*applyfilters.Input, *applyfilters.Output]{},
+			fetchAllDiffsFactory:       &mockActivityFactory[*fetchalldiffs.Input, *fetchalldiffs.Output]{},
+			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
+			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
+			composeCommitFactory:       &mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+			composeFlatCommitFactory:   nil,
+			commitConfigProvider:       &mockCommitConfigProvider{},
+			commandParametersReader:    &mockCommandParametersReader{},
+			outputWriter:               &mockOutputWriter{},
+			wantErr:                    true,
+			expectedErrMsg:             "composeFlatCommitFactory is nil",
 		},
 		{
 			name:                       "nil commitConfigProvider",
@@ -223,6 +248,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composeCommitFactory:       &mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+			composeFlatCommitFactory:   &mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 			commitConfigProvider:       nil,
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -238,6 +264,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composeCommitFactory:       &mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+			composeFlatCommitFactory:   &mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 			commitConfigProvider:       &mockCommitConfigProvider{},
 			commandParametersReader:    nil,
 			outputWriter:               &mockOutputWriter{},
@@ -253,6 +280,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composeCommitFactory:       &mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+			composeFlatCommitFactory:   &mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 			commitConfigProvider:       &mockCommitConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               nil,
@@ -268,6 +296,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composeCommitFactory:       &mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+			composeFlatCommitFactory:   &mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 			commitConfigProvider:       &mockCommitConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -285,6 +314,7 @@ func TestNewFactory(t *testing.T) {
 				tt.fetchAllBranchDiffsFactory,
 				tt.summarizeAllFactory,
 				tt.composeCommitFactory,
+				tt.composeFlatCommitFactory,
 				tt.commitConfigProvider,
 				tt.commandParametersReader,
 				tt.outputWriter,
@@ -342,6 +372,7 @@ func TestFactory_NewFlow(t *testing.T) {
 					&mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 					&mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 					&mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+					&mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 					&mockCommitConfigProvider{},
 					&mockCommandParametersReader{},
 					&mockOutputWriter{},
@@ -365,6 +396,7 @@ func TestFactory_NewFlow(t *testing.T) {
 					&mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 					&mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 					&mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+					&mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 					&mockCommitConfigProvider{},
 					&mockCommandParametersReader{},
 					&mockOutputWriter{},
@@ -392,6 +424,7 @@ func TestFactory_NewFlow(t *testing.T) {
 					&mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 					&mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 					&mockActivityFactory[*composecommit.Input, *composecommit.Output]{},
+					&mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 					&mockCommitConfigProvider{},
 					mockReader,
 					&mockOutputWriter{},
@@ -464,6 +497,7 @@ func TestFactory_NewFlow(t *testing.T) {
 							}
 						},
 					},
+					&mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 					mockConfig,
 					mockReader,
 					&mockOutputWriter{},
@@ -536,6 +570,7 @@ func TestFactory_NewFlow(t *testing.T) {
 							}
 						},
 					},
+					&mockActivityFactory[*composeflatcommit.Input, *composeflatcommit.Output]{},
 					mockConfig,
 					mockReader,
 					&mockOutputWriter{},

--- a/internal/flows/pullrequest/flow.go
+++ b/internal/flows/pullrequest/flow.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/retran/meowg1k/internal/activities/applyfilters"
+	"github.com/retran/meowg1k/internal/activities/composeflatpr"
 	"github.com/retran/meowg1k/internal/activities/composepr"
 	"github.com/retran/meowg1k/internal/activities/fetchallbranchdiffs"
 	"github.com/retran/meowg1k/internal/activities/listbranchfiles"
@@ -51,6 +52,7 @@ type Factory struct {
 	fetchAllBranchDiffsFactory executor.ActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]
 	summarizeAllFactory        executor.ActivityFactory[*summarizeall.Input, *summarizeall.Output]
 	composePRFactory           executor.ActivityFactory[*composepr.Input, *composepr.Output]
+	composeFlatPRFactory       executor.ActivityFactory[*composeflatpr.Input, *composeflatpr.Output]
 	prConfigProvider           PullRequestConfigProvider
 	commandParametersReader    CommandParametersReader
 	outputWriter               ports.OutputWriter
@@ -63,6 +65,7 @@ func NewFactory(
 	fetchAllBranchDiffsFactory executor.ActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output],
 	summarizeAllFactory executor.ActivityFactory[*summarizeall.Input, *summarizeall.Output],
 	composePRFactory executor.ActivityFactory[*composepr.Input, *composepr.Output],
+	composeFlatPRFactory executor.ActivityFactory[*composeflatpr.Input, *composeflatpr.Output],
 	prConfigProvider PullRequestConfigProvider,
 	commandParametersReader CommandParametersReader,
 	outputWriter ports.OutputWriter,
@@ -87,6 +90,10 @@ func NewFactory(
 		return nil, fmt.Errorf("composePRFactory is nil")
 	}
 
+	if composeFlatPRFactory == nil {
+		return nil, fmt.Errorf("composeFlatPRFactory is nil")
+	}
+
 	if prConfigProvider == nil {
 		return nil, fmt.Errorf("prConfigProvider is nil")
 	}
@@ -105,6 +112,7 @@ func NewFactory(
 		fetchAllBranchDiffsFactory: fetchAllBranchDiffsFactory,
 		summarizeAllFactory:        summarizeAllFactory,
 		composePRFactory:           composePRFactory,
+		composeFlatPRFactory:       composeFlatPRFactory,
 		prConfigProvider:           prConfigProvider,
 		commandParametersReader:    commandParametersReader,
 		outputWriter:               outputWriter,
@@ -196,25 +204,7 @@ func (f *Factory) NewFlow() executor.Flow {
 		var changes []*git.FileChange
 		changes = append(changes, fetchAllBranchDiffsOutput.Changes...)
 
-		// Phase 4: Summarize changes for all files
-		summarizeAll := f.summarizeAllFactory.NewActivity()
-		summarizeAllFuture := executor.ExecuteActivity(
-			flowCtx.GetExecutor(),
-			ctx,
-			flowCtx,
-			"SummarizeAll",
-			summarizeAll,
-			&summarizeall.Input{
-				Changes: changes,
-			},
-		)
-
-		summarizeAllOutput, err := summarizeAllFuture.Get(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to summarize changes: %w", err)
-		}
-
-		// Phase 5: Compose PR description
+		// Get configuration
 		cfg, err := f.prConfigProvider.Get()
 		if err != nil {
 			return fmt.Errorf("failed to resolve PR configuration: %w", err)
@@ -234,29 +224,77 @@ func (f *Factory) NewFlow() executor.Flow {
 			intent = stdin
 		}
 
-		composePR := f.composePRFactory.NewActivity()
-		prFuture := executor.ExecuteActivity(
-			flowCtx.GetExecutor(),
-			ctx,
-			flowCtx,
-			"ComposePR",
-			composePR,
-			&composepr.Input{
-				Profile:      cfg.Profile,
-				SystemPrompt: cfg.SystemPrompt,
-				Summaries:    summarizeAllOutput.Summaries,
-				Intent:       intent,
-			},
-		)
+		var prDescription string
 
-		prResult, err := prFuture.Get(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to compose PR description: %w", err)
+		// Phase 4 & 5: Compose PR description based on strategy
+		if cfg.Strategy == "flat" {
+			// Flat strategy: send full diff directly to LLM
+			composeFlatPR := f.composeFlatPRFactory.NewActivity()
+			flatPRFuture := executor.ExecuteActivity(
+				flowCtx.GetExecutor(),
+				ctx,
+				flowCtx,
+				"ComposeFlatPR",
+				composeFlatPR,
+				&composeflatpr.Input{
+					Profile:      cfg.Profile,
+					SystemPrompt: cfg.SystemPrompt,
+					Changes:      changes,
+					Intent:       intent,
+				},
+			)
+
+			flatPRResult, err := flatPRFuture.Get(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to compose PR description using flat strategy: %w", err)
+			}
+
+			prDescription = flatPRResult.Description
+		} else {
+			// Summarize strategy (default): use map-reduce approach
+			summarizeAll := f.summarizeAllFactory.NewActivity()
+			summarizeAllFuture := executor.ExecuteActivity(
+				flowCtx.GetExecutor(),
+				ctx,
+				flowCtx,
+				"SummarizeAll",
+				summarizeAll,
+				&summarizeall.Input{
+					Changes: changes,
+				},
+			)
+
+			summarizeAllOutput, err := summarizeAllFuture.Get(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to summarize changes: %w", err)
+			}
+
+			composePR := f.composePRFactory.NewActivity()
+			prFuture := executor.ExecuteActivity(
+				flowCtx.GetExecutor(),
+				ctx,
+				flowCtx,
+				"ComposePR",
+				composePR,
+				&composepr.Input{
+					Profile:      cfg.Profile,
+					SystemPrompt: cfg.SystemPrompt,
+					Summaries:    summarizeAllOutput.Summaries,
+					Intent:       intent,
+				},
+			)
+
+			prResult, err := prFuture.Get(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to compose PR description: %w", err)
+			}
+
+			prDescription = prResult.PRDescription
 		}
 
 		flowCtx.SendCompleted("")
 
-		if err := f.outputWriter.PrintLine(prResult.PRDescription); err != nil {
+		if err := f.outputWriter.PrintLine(prDescription); err != nil {
 			return fmt.Errorf("failed to print PR description: %w", err)
 		}
 

--- a/internal/flows/pullrequest/flow_test.go
+++ b/internal/flows/pullrequest/flow_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/retran/meowg1k/internal/activities/applyfilters"
+	"github.com/retran/meowg1k/internal/activities/composeflatpr"
 	"github.com/retran/meowg1k/internal/activities/composepr"
 	"github.com/retran/meowg1k/internal/activities/fetchallbranchdiffs"
 	"github.com/retran/meowg1k/internal/activities/listbranchfiles"
@@ -97,6 +98,7 @@ func TestNewFactory(t *testing.T) {
 		fetchAllBranchDiffsFactory executor.ActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]
 		summarizeAllFactory        executor.ActivityFactory[*summarizeall.Input, *summarizeall.Output]
 		composePRFactory           executor.ActivityFactory[*composepr.Input, *composepr.Output]
+		composeFlatPRFactory       executor.ActivityFactory[*composeflatpr.Input, *composeflatpr.Output]
 		prConfigProvider           PullRequestConfigProvider
 		commandParametersReader    CommandParametersReader
 		outputWriter               ports.OutputWriter
@@ -110,6 +112,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composePRFactory:           &mockActivityFactory[*composepr.Input, *composepr.Output]{},
+			composeFlatPRFactory:       &mockActivityFactory[*composeflatpr.Input, *composeflatpr.Output]{},
 			prConfigProvider:           &mockPRConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -123,6 +126,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composePRFactory:           &mockActivityFactory[*composepr.Input, *composepr.Output]{},
+			composeFlatPRFactory:       &mockActivityFactory[*composeflatpr.Input, *composeflatpr.Output]{},
 			prConfigProvider:           &mockPRConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -136,6 +140,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: nil,
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composePRFactory:           &mockActivityFactory[*composepr.Input, *composepr.Output]{},
+			composeFlatPRFactory:       &mockActivityFactory[*composeflatpr.Input, *composeflatpr.Output]{},
 			prConfigProvider:           &mockPRConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -149,6 +154,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        nil,
 			composePRFactory:           &mockActivityFactory[*composepr.Input, *composepr.Output]{},
+			composeFlatPRFactory:       &mockActivityFactory[*composeflatpr.Input, *composeflatpr.Output]{},
 			prConfigProvider:           &mockPRConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -162,11 +168,26 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composePRFactory:           nil,
+			composeFlatPRFactory:       &mockActivityFactory[*composeflatpr.Input, *composeflatpr.Output]{},
 			prConfigProvider:           &mockPRConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
 			wantErr:                    true,
 			expectedErrMsg:             "composePRFactory is nil",
+		},
+		{
+			name:                       "nil composeFlatPRFactory",
+			listBranchFilesFactory:     &mockActivityFactory[*listbranchfiles.Input, *listbranchfiles.Output]{},
+			applyFiltersFactory:        &mockActivityFactory[*applyfilters.Input, *applyfilters.Output]{},
+			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
+			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
+			composePRFactory:           &mockActivityFactory[*composepr.Input, *composepr.Output]{},
+			composeFlatPRFactory:       nil,
+			prConfigProvider:           &mockPRConfigProvider{},
+			commandParametersReader:    &mockCommandParametersReader{},
+			outputWriter:               &mockOutputWriter{},
+			wantErr:                    true,
+			expectedErrMsg:             "composeFlatPRFactory is nil",
 		},
 		{
 			name:                       "nil prConfigProvider",
@@ -175,6 +196,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composePRFactory:           &mockActivityFactory[*composepr.Input, *composepr.Output]{},
+			composeFlatPRFactory:       &mockActivityFactory[*composeflatpr.Input, *composeflatpr.Output]{},
 			prConfigProvider:           nil,
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -188,6 +210,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composePRFactory:           &mockActivityFactory[*composepr.Input, *composepr.Output]{},
+			composeFlatPRFactory:       &mockActivityFactory[*composeflatpr.Input, *composeflatpr.Output]{},
 			prConfigProvider:           &mockPRConfigProvider{},
 			commandParametersReader:    nil,
 			outputWriter:               &mockOutputWriter{},
@@ -201,6 +224,7 @@ func TestNewFactory(t *testing.T) {
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composePRFactory:           &mockActivityFactory[*composepr.Input, *composepr.Output]{},
+			composeFlatPRFactory:       &mockActivityFactory[*composeflatpr.Input, *composeflatpr.Output]{},
 			prConfigProvider:           &mockPRConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               nil,
@@ -208,12 +232,13 @@ func TestNewFactory(t *testing.T) {
 			expectedErrMsg:             "outputWriter is nil",
 		},
 		{
-			name:                       "all valid dependencies",
+			name:                       "all factories provided",
 			listBranchFilesFactory:     &mockActivityFactory[*listbranchfiles.Input, *listbranchfiles.Output]{},
 			applyFiltersFactory:        &mockActivityFactory[*applyfilters.Input, *applyfilters.Output]{},
 			fetchAllBranchDiffsFactory: &mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 			summarizeAllFactory:        &mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 			composePRFactory:           &mockActivityFactory[*composepr.Input, *composepr.Output]{},
+			composeFlatPRFactory:       &mockActivityFactory[*composeflatpr.Input, *composeflatpr.Output]{},
 			prConfigProvider:           &mockPRConfigProvider{},
 			commandParametersReader:    &mockCommandParametersReader{},
 			outputWriter:               &mockOutputWriter{},
@@ -229,6 +254,7 @@ func TestNewFactory(t *testing.T) {
 				tt.fetchAllBranchDiffsFactory,
 				tt.summarizeAllFactory,
 				tt.composePRFactory,
+				tt.composeFlatPRFactory,
 				tt.prConfigProvider,
 				tt.commandParametersReader,
 				tt.outputWriter,
@@ -284,6 +310,7 @@ func TestFactory_NewFlow(t *testing.T) {
 					&mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 					&mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 					&mockActivityFactory[*composepr.Input, *composepr.Output]{},
+					&mockActivityFactory[*composeflatpr.Input, *composeflatpr.Output]{},
 					&mockPRConfigProvider{},
 					&mockCommandParametersReader{},
 					&mockOutputWriter{},
@@ -305,6 +332,7 @@ func TestFactory_NewFlow(t *testing.T) {
 					&mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 					&mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 					&mockActivityFactory[*composepr.Input, *composepr.Output]{},
+					&mockActivityFactory[*composeflatpr.Input, *composeflatpr.Output]{},
 					&mockPRConfigProvider{},
 					&mockCommandParametersReader{},
 					&mockOutputWriter{},
@@ -330,6 +358,7 @@ func TestFactory_NewFlow(t *testing.T) {
 					&mockActivityFactory[*fetchallbranchdiffs.Input, *fetchallbranchdiffs.Output]{},
 					&mockActivityFactory[*summarizeall.Input, *summarizeall.Output]{},
 					&mockActivityFactory[*composepr.Input, *composepr.Output]{},
+					&mockActivityFactory[*composeflatpr.Input, *composeflatpr.Output]{},
 					&mockPRConfigProvider{},
 					mockReader,
 					&mockOutputWriter{},


### PR DESCRIPTION
### **Description:**

#### Summary

This pull request introduces a new execution strategy, `"flat"`, for the `commit` and `pullrequest` commands. The existing Map-Reduce (`"summarize"`) strategy is powerful for large, complex changes but introduces unnecessary latency for small, iterative commits.

The new `"flat"` strategy significantly speeds up the workflow for small changes by sending the entire git diff directly to the LLM in a single request, bypassing the file-by-file summarization pipeline.

#### Key Changes

* **New `strategy` Configuration:**
    * Added an optional `strategy` field to the `commit` and `pullRequest` sections in `config.yaml`.
    * `"summarize"` (default): The existing Map-Reduce behavior.
    * `"flat"`: A new mode that sends the full diff directly to the model.

* **"Flat" Strategy Implementation:**
    * Created new activities (`composeflatcommit`, `composeflatpr`) to handle the "flat" workflow.
    * Includes a crucial safety check: if the diff size is estimated to exceed the model's `maxInputTokens` limit, the command fails with a clear error message, suggesting the user switch to the `"summarize"` strategy.

* **Code Refactoring & Quality:**
    * The initial `composeflatcommit` and `composeflatpr` activities were refactored into a single, generic `composeflat` activity to eliminate code duplication and improve maintainability.
    * The command-specific activities are now thin, clean wrappers around this generic implementation.

* **Comprehensive Documentation:**
    * The new feature is fully documented across the board:
        * Updated `02-CONFIGURATION.md` with details on the `strategy` field.
        * Updated `03-COMMAND-REFERENCE.md` to explain the new strategies for both commands.
        * Added a new `04-EXAMPLES.md` recipe for using the `flat` strategy for fast commits.
        * Updated all relevant `man` pages (`meow-commit.1`, `meow-pullrequest.1`, `meow-config.5`).

* **Model Registry Update:**
    * The model registry (`internal/core/model/registry.go`) has been significantly updated and reorganized with the latest Anthropic and Google models, ensuring the tool remains current.
    
Refs: #32 