### PR TITLE
fix(activities): handle additional Git error for file existence check

### DIFF
--- a/internal/activities/fetchbranchfilediff/activity.go
+++ b/internal/activities/fetchbranchfilediff/activity.go
@@ -79,7 +79,9 @@ func (f *Factory) NewActivity() executor.Activity[*Input, *git.FileChange] {
 		// For branch diff, we get content from target branch (base) and current HEAD
 		originalFileContent, err := f.branchDiffReader.ReadOriginalFileContent(input.Filename)
 		if err != nil {
-			if strings.Contains(err.Error(), "does not exist") || strings.Contains(err.Error(), "not in 'HEAD'") {
+			if strings.Contains(err.Error(), "does not exist") ||
+				strings.Contains(err.Error(), "not in 'HEAD'") ||
+				strings.Contains(err.Error(), "path not in the working tree") {
 				originalFileContent = "" // File is new
 			} else {
 				return nil, fmt.Errorf("failed to read original file content of %s: %w", input.Filename, err)
@@ -89,7 +91,8 @@ func (f *Factory) NewActivity() executor.Activity[*Input, *git.FileChange] {
 		// For branch diff, "staged" content is actually current HEAD content
 		stagedFileContent, err := f.branchDiffReader.ReadStagedFileContent(input.Filename)
 		if err != nil {
-			if strings.Contains(err.Error(), "does not exist") {
+			if strings.Contains(err.Error(), "does not exist") ||
+				strings.Contains(err.Error(), "path not in the working tree") {
 				// File was deleted - return with empty staged content
 				executorCtx.SendCompleted("Deleted")
 				return &git.FileChange{


### PR DESCRIPTION
The activity now properly handles the "path not in the working tree" Git error message when checking file existence. This expands the error conditions under which files are considered non-existent, improving the robustness of file diff operations.

Previously, only a limited set of Git error messages were treated as indicators of non-existent files. This change adds the additional error case to ensure more accurate file existence detection during branch file diff operations.