### PR TITLE
refactor: improve concurrency safety

### DIFF
--- a/.meowg1k.yaml
+++ b/.meowg1k.yaml
@@ -11,15 +11,15 @@ models:
     provider: "gemini"
     model: "gemini-2.5-flash"
     rateLimit:
-      requestsPerMinute: 60
-      tokensPerMinute: 1000000
+      requestsPerMinute: 1000
+      tokensPerMinute: 2000000
       requestsPerDay: 10000
 
   gemini-pro:
     provider: "gemini"
     model: "gemini-2.5-pro"
     rateLimit:
-      requestsPerMinute: 60
+      requestsPerMinute: 150
       tokensPerMinute: 1000000
       requestsPerDay: 10000
 

--- a/.meowg1k.yaml
+++ b/.meowg1k.yaml
@@ -7,13 +7,22 @@ models:
       tokensPerMinute: 1000000
       requestsPerDay: 10000
 
-  qwen-plus:
-    provider: "openrouter"
-    model: "qwen/qwen3-coder-plus"
+  gemini-flash:
+    provider: "gemini"
+    model: "gemini-2.5-flash"
     rateLimit:
       requestsPerMinute: 60
       tokensPerMinute: 1000000
       requestsPerDay: 10000
+
+  gemini-pro:
+    provider: "gemini"
+    model: "gemini-2.5-pro"
+    rateLimit:
+      requestsPerMinute: 60
+      tokensPerMinute: 1000000
+      requestsPerDay: 10000
+
 
   gemini-embeddings:
     provider: "gemini"
@@ -34,14 +43,14 @@ models:
 
 profiles:
   fast:
-    model: "qwen-flash"
+    model: "gemini-flash"
     temperature: 0.3
     cache:
       enabled: true
       ttl: "24h"
 
   smart:
-    model: "qwen-plus"
+    model: "gemini-pro"
     timeout: "10m"
     temperature: 0.2
     topP: 0.95

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -244,9 +244,15 @@ func (e *executorImpl) ExecuteActivity(
 
 	go func() {
 		// Acquire worker slot if semaphore is configured
+		// We must handle context cancellation to avoid goroutines getting stuck
 		if e.workerSemaphore != nil {
-			e.workerSemaphore <- struct{}{}
-			defer func() { <-e.workerSemaphore }()
+			select {
+			case e.workerSemaphore <- struct{}{}:
+				defer func() { <-e.workerSemaphore }()
+			case <-ctx.Done():
+				_ = fut.CompleteWithError(fmt.Errorf("activity %q canceled while waiting for worker slot: %w", fullActivityName, ctx.Err()))
+				return
+			}
 		}
 
 		result, err := e.executeActivityImpl(ctx, activityCtx, activity, input, e.RetryPolicy)

--- a/pkg/future/future.go
+++ b/pkg/future/future.go
@@ -158,7 +158,9 @@ func (f *Future[T]) TryGet() (T, error, bool) {
 	}
 }
 
-// WaitAll waits for all futures to complete and returns all results
+// WaitAll waits for all futures to complete and returns all results.
+// This function waits for all futures concurrently (not sequentially),
+// which prevents deadlock scenarios when combined with concurrency limiting.
 func WaitAll[T any](ctx context.Context, futures ...*Future[T]) ([]T, []error) {
 	if ctx == nil {
 		return nil, []error{fmt.Errorf("context is nil")}
@@ -167,15 +169,28 @@ func WaitAll[T any](ctx context.Context, futures ...*Future[T]) ([]T, []error) {
 	results := make([]T, len(futures))
 	errs := make([]error, len(futures))
 
+	// Use a WaitGroup to wait for all goroutines to complete
+	var wg sync.WaitGroup
+
+	// Launch a goroutine for each future to wait concurrently
 	for i, future := range futures {
-		if future == nil {
-			errs[i] = fmt.Errorf("future at index %d is nil", i)
-			continue
-		}
-		result, err := future.Get(ctx)
-		results[i] = result
-		errs[i] = err
+		wg.Add(1)
+		go func(idx int, fut *Future[T]) {
+			defer wg.Done()
+
+			if fut == nil {
+				errs[idx] = fmt.Errorf("future at index %d is nil", idx)
+				return
+			}
+
+			result, err := fut.Get(ctx)
+			results[idx] = result
+			errs[idx] = err
+		}(i, future)
 	}
+
+	// Wait for all goroutines to complete
+	wg.Wait()
 
 	return results, errs
 }

--- a/pkg/future/future.go
+++ b/pkg/future/future.go
@@ -171,6 +171,8 @@ func WaitAll[T any](ctx context.Context, futures ...*Future[T]) ([]T, []error) {
 
 	// Use a WaitGroup to wait for all goroutines to complete
 	var wg sync.WaitGroup
+	// Use a mutex to protect concurrent writes to results and errs slices
+	var mu sync.Mutex
 
 	// Launch a goroutine for each future to wait concurrently
 	for i, future := range futures {
@@ -179,13 +181,17 @@ func WaitAll[T any](ctx context.Context, futures ...*Future[T]) ([]T, []error) {
 			defer wg.Done()
 
 			if fut == nil {
+				mu.Lock()
 				errs[idx] = fmt.Errorf("future at index %d is nil", idx)
+				mu.Unlock()
 				return
 			}
 
 			result, err := fut.Get(ctx)
+			mu.Lock()
 			results[idx] = result
 			errs[idx] = err
+			mu.Unlock()
 		}(i, future)
 	}
 


### PR DESCRIPTION
## Summary
This pull request introduces critical improvements to the concurrency handling within the task executor and future management systems to prevent deadlocks and resource leaks. The `future.WaitAll` function is now fully concurrent, and the executor's worker acquisition process is now responsive to context cancellation. Additionally, this PR updates the AI model configuration, migrating from Qwen to Gemini models.

## Motivation
The previous implementation had two significant concurrency issues:
1.  The `future.WaitAll` function processed futures sequentially. When used in a system with a limited number of concurrent workers, this could lead to deadlocks where `WaitAll` was waiting for a future that couldn't be processed because all workers were occupied by the `WaitAll` calls themselves.
2.  In `executor.ExecuteActivity`, a goroutine could block indefinitely while waiting to acquire a worker semaphore if the parent context was cancelled during the wait. This led to leaked goroutines and unresponsive cancellation.

These changes are essential for improving the stability, reliability, and performance of our concurrent task processing system.

## Changes
- **Core Changes**
    - `pkg/future/future.go`: Refactored `WaitAll` to process futures concurrently. It now launches a goroutine for each future's `Get` call and uses a `sync.WaitGroup` to await their completion, eliminating the risk of deadlocks.
    - `pkg/executor/executor.go`: Updated `ExecuteActivity` to handle context cancellation while waiting for a worker. A `select` statement now allows the operation to be aborted if the context is done, preventing goroutines from getting stuck.

- **Configuration**
    - `.meowg1k.yaml`: Replaced Qwen models with Gemini models. `qwen-plus` is now `gemini-flash`, and a new `gemini-pro` model has been added. Rate limits for `gemini-flash` have been significantly increased.

## Technical Details
The primary architectural change is in `future.WaitAll`, moving from a sequential iteration to a concurrent fan-out/fan-in pattern using goroutines and a `WaitGroup`. This is a more robust approach for waiting on multiple asynchronous operations, especially in resource-constrained environments.

The fix in `executor.go` is a standard Go concurrency pattern for making blocking operations cancellable. By adding a `case <-ctx.Done()` to the `select` block around the semaphore acquisition, we ensure that the executor respects context deadlines and cancellations promptly.