### PR TITLE
fix(fetchfilediff): handle 'unknown revision' error for deleted files

### DIFF
--- a/internal/activities/fetchfilediff/activity.go
+++ b/internal/activities/fetchfilediff/activity.go
@@ -74,7 +74,8 @@ func (f *Factory) NewActivity() executor.Activity[*Input, *git.FileChange] {
 
 		stagedFileContent, err := f.stagedChangesReader.ReadStagedFileContent(input.Filename)
 		if err != nil {
-			if strings.Contains(err.Error(), "does not exist") {
+			if strings.Contains(err.Error(), "does not exist") ||
+				strings.Contains(err.Error(), "unknown revision or path not in the working tree") {
 				// File was deleted - return with empty staged content but include original content and diff
 				executorCtx.SendCompleted("Deleted")
 				return &git.FileChange{

--- a/internal/activities/fetchfilediff/activity_test.go
+++ b/internal/activities/fetchfilediff/activity_test.go
@@ -220,6 +220,41 @@ func TestActivity_DeletedFileScenario(t *testing.T) {
 	}
 }
 
+func TestActivity_DeletedFileWithUnknownRevisionError(t *testing.T) {
+	gitSvc := &mockStagedChangesReader{
+		ReadStagedChangesFunc: func(filename string) (string, error) {
+			return "diff for deleted file", nil
+		},
+		ReadOriginalFileContentFunc: func(filename string) (string, error) {
+			return "original content", nil
+		},
+		ReadStagedFileContentFunc: func(filename string) (string, error) {
+			return "", fmt.Errorf("fatal: ambiguous argument ':.meowg1k/config.yaml': unknown revision or path not in the working tree")
+		},
+	}
+	factory, _ := NewFactory(gitSvc)
+	activity := factory.NewActivity()
+
+	ctx := context.Background()
+	execCtx := executor.NewContext("test", nil, nil)
+	input := &Input{Filename: ".meowg1k/config.yaml"}
+
+	output, err := activity(ctx, execCtx, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if output.ChangedFileContent != "" {
+		t.Errorf("expected empty staged content for deleted file, got %q", output.ChangedFileContent)
+	}
+	if output.OriginalFileContent != "original content" {
+		t.Errorf("expected original content, got %q", output.OriginalFileContent)
+	}
+	if output.Change != "diff for deleted file" {
+		t.Errorf("expected diff content, got %q", output.Change)
+	}
+}
+
 func TestActivity_InitialCommitScenario(t *testing.T) {
 	gitSvc := &mockStagedChangesReader{
 		ReadStagedChangesFunc: func(filename string) (string, error) {

--- a/internal/activities/fetchfilediff/activity_test.go
+++ b/internal/activities/fetchfilediff/activity_test.go
@@ -229,7 +229,7 @@ func TestActivity_DeletedFileWithUnknownRevisionError(t *testing.T) {
 			return "original content", nil
 		},
 		ReadStagedFileContentFunc: func(filename string) (string, error) {
-			return "", fmt.Errorf("fatal: ambiguous argument ':.meowg1k/config.yaml': unknown revision or path not in the working tree")
+			return "", fmt.Errorf("fatal: ambiguous argument '%s': unknown revision or path not in the working tree", filename)
 		},
 	}
 	factory, _ := NewFactory(gitSvc)


### PR DESCRIPTION
The `fetchfilediff` activity would previously fail when processing a file deletion. This occurred because the Git command to read the file's content from the new commit would return an "unknown revision or path not in the working tree" error, which was not handled as a file-not-found scenario.

This change updates the error handling to correctly interpret this specific Git error as an indication that the file does not exist in the new commit. This allows the activity to complete successfully, returning the correct diff for a deleted file.