### PR TITLE
refactor(index): use slice for deterministic file processing

### DIFF
--- a/internal/activities/chunkallfiles/activity.go
+++ b/internal/activities/chunkallfiles/activity.go
@@ -16,7 +16,7 @@ import (
 
 type Input struct {
 	StateName string
-	Files     map[string]domainindex.FileState
+	Files     []domainindex.FileToProcess
 }
 
 type FileChunkResult struct {
@@ -60,25 +60,33 @@ func (f *Factory) NewActivity() executor.Activity[*Input, *Output] {
 			return nil, fmt.Errorf("executor not available in context")
 		}
 
-		chunkFutures := make(map[string]*future.Future[*chunkfile.Output])
-		for filePath, fileState := range input.Files {
+		type chunkFuture struct {
+			file   domainindex.FileToProcess
+			future *future.Future[*chunkfile.Output]
+		}
+		chunkFutures := make([]chunkFuture, 0, len(input.Files))
+
+		for _, file := range input.Files {
 			activity := f.chunkFileFactory.NewActivity()
 			fileInput := &chunkfile.Input{
-				FilePath: filePath,
-				Content:  fileState.Content,
+				FilePath: file.FilePath,
+				Content:  file.State.Content,
 			}
-			fut := executor.ExecuteActivity(exec, ctx, executorCtx, fmt.Sprintf("Chunk_%s", filePath), activity, fileInput)
-			chunkFutures[filePath] = fut
+			fut := executor.ExecuteActivity(exec, ctx, executorCtx, fmt.Sprintf("Chunk_%s", file.FilePath), activity, fileInput)
+			chunkFutures = append(chunkFutures, chunkFuture{
+				file:   file,
+				future: fut,
+			})
 		}
 
 		var fileChunks []FileChunkResult
 		var allChunkTexts []string
 		var chunkToFileIndex []int
 
-		for filePath, fut := range chunkFutures {
-			result, err := fut.Get(ctx)
+		for _, entry := range chunkFutures {
+			result, err := entry.future.Get(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("failed to chunk file %s: %w", filePath, err)
+				return nil, fmt.Errorf("failed to chunk file %s: %w", entry.file.FilePath, err)
 			}
 
 			fileIndex := len(fileChunks)
@@ -93,7 +101,7 @@ func (f *Factory) NewActivity() executor.Activity[*Input, *Output] {
 				chunkToFileIndex = append(chunkToFileIndex, fileIndex)
 			}
 			for _, chunk := range result.Chunks {
-				chunkText := formatChunkWithMetadata(chunk, filePath, input.StateName)
+				chunkText := formatChunkWithMetadata(chunk, result.FilePath, input.StateName)
 				allChunkTexts = append(allChunkTexts, chunkText)
 			}
 		}

--- a/internal/activities/chunkallfiles/activity_test.go
+++ b/internal/activities/chunkallfiles/activity_test.go
@@ -121,9 +121,21 @@ func TestActivity(t *testing.T) {
 
 		input := &Input{
 			StateName: "test_state",
-			Files: map[string]domainindex.FileState{
-				"file1.go": {ContentHash: "hash1", Content: []byte("content1")},
-				"file2.go": {ContentHash: "hash2", Content: []byte("content2")},
+			Files: []domainindex.FileToProcess{
+				{
+					FilePath: "file1.go",
+					State: domainindex.FileState{
+						ContentHash: "hash1",
+						Content:     []byte("content1"),
+					},
+				},
+				{
+					FilePath: "file2.go",
+					State: domainindex.FileState{
+						ContentHash: "hash2",
+						Content:     []byte("content2"),
+					},
+				},
 			},
 		}
 
@@ -147,31 +159,24 @@ func TestActivity(t *testing.T) {
 			t.Fatalf("expected 3 ChunkToFileIndex entries, got %d", len(output.ChunkToFileIndex))
 		}
 
-		// Since map iteration order is not guaranteed, we need to be flexible about the index mapping
-		// Just verify that the indices are valid and the counts are correct
-		for _, idx := range output.ChunkToFileIndex {
-			if idx < 0 || idx >= len(output.FileChunks) {
-				t.Errorf("invalid file index %d", idx)
+		expectedOrder := []string{"file1.go", "file2.go"}
+		for i, chunk := range output.FileChunks {
+			if chunk.FilePath != expectedOrder[i] {
+				t.Errorf("expected file %s at index %d, got %s", expectedOrder[i], i, chunk.FilePath)
 			}
 		}
 
-		// Count chunks per file index
-		chunkCounts := make(map[int]int)
-		for _, idx := range output.ChunkToFileIndex {
-			chunkCounts[idx]++
-		}
-
-		// We should have exactly 2 files, one with 2 chunks and one with 1 chunk
-		if len(chunkCounts) != 2 {
-			t.Errorf("expected chunks for 2 files, got chunks for %d files", len(chunkCounts))
-		}
-
-		totalChunks := 0
-		for _, count := range chunkCounts {
-			totalChunks += count
-		}
-		if totalChunks != 3 {
-			t.Errorf("expected 3 total chunks, got %d", totalChunks)
+		expectedChunkCounts := []int{2, 1}
+		for fileIdx, expectedCount := range expectedChunkCounts {
+			count := 0
+			for _, idx := range output.ChunkToFileIndex {
+				if idx == fileIdx {
+					count++
+				}
+			}
+			if count != expectedCount {
+				t.Errorf("expected %d chunks for file index %d, got %d", expectedCount, fileIdx, count)
+			}
 		}
 	})
 
@@ -184,7 +189,7 @@ func TestActivity(t *testing.T) {
 		exec := &mockExecutor{}
 		ctx := context.Background()
 		executorCtx := executor.NewContext("test", executor.NoOpFeedbackHandler, exec)
-		input := &Input{StateName: "empty_state", Files: map[string]domainindex.FileState{}}
+		input := &Input{StateName: "empty_state", Files: []domainindex.FileToProcess{}}
 
 		// Act
 		output, err := activityFunc(ctx, executorCtx, input)
@@ -208,7 +213,7 @@ func TestActivity(t *testing.T) {
 
 		ctx := context.Background()
 		executorCtx := executor.NewContext("test", executor.NoOpFeedbackHandler, nil) // No executor
-		input := &Input{StateName: "test", Files: map[string]domainindex.FileState{}}
+		input := &Input{StateName: "test", Files: []domainindex.FileToProcess{}}
 
 		// Act
 		_, err := activityFunc(ctx, executorCtx, input)
@@ -244,7 +249,12 @@ func TestActivity(t *testing.T) {
 		executorCtx := executor.NewContext("test", executor.NoOpFeedbackHandler, exec)
 		input := &Input{
 			StateName: "fail_state",
-			Files:     map[string]domainindex.FileState{"fail.go": {}},
+			Files: []domainindex.FileToProcess{
+				{
+					FilePath: "fail.go",
+					State:    domainindex.FileState{},
+				},
+			},
 		}
 
 		// Act

--- a/internal/activities/deduplicateandprepare/activity.go
+++ b/internal/activities/deduplicateandprepare/activity.go
@@ -24,8 +24,8 @@ type Output struct {
 	ExistingVersions map[string]int64
 
 	// FilesToProcess contains files that need to be chunked, embedded, and saved
-	// Maps a synthetic file path (first encountered) to file state (only unique files not in DB)
-	FilesToProcess map[string]domainindex.FileState
+	// Each entry preserves the source file path and its associated state
+	FilesToProcess []domainindex.FileToProcess
 
 	// ContentHashToVersionID maps content hash to version ID for all files (used in finalization)
 	// Will be populated with both existing and new versions

--- a/internal/adapters/config/service_test.go
+++ b/internal/adapters/config/service_test.go
@@ -46,6 +46,11 @@ generate:
 		t.Fatalf("Failed to create temp config file: %v", err)
 	}
 
+	cleanEnvDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cleanEnvDir)
+	t.Setenv("HOME", cleanEnvDir)
+	t.Setenv("XDG_CONFIG_DIRS", "")
+
 	// Create command with config flag
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("config", "", "config file path")
@@ -167,6 +172,11 @@ func TestNewServiceWithoutConfig(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("config", "", "config file path")
 	// Don't set the config flag
+
+	cleanEnvDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cleanEnvDir)
+	t.Setenv("HOME", cleanEnvDir)
+	t.Setenv("XDG_CONFIG_DIRS", "")
 
 	commandSvc, err := command.NewService(cmd)
 	if err != nil {

--- a/internal/app/container_test.go
+++ b/internal/app/container_test.go
@@ -519,6 +519,11 @@ generate:
 		t.Fatalf("Failed to create config file: %v", err)
 	}
 
+	cleanEnvDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cleanEnvDir)
+	t.Setenv("HOME", cleanEnvDir)
+	t.Setenv("XDG_CONFIG_DIRS", "")
+
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("config", "", "config file path")
 	cmd.Flags().String("task", "", "task name")

--- a/internal/core/index/service.go
+++ b/internal/core/index/service.go
@@ -41,7 +41,7 @@ func NewService(
 
 type PrepareOutput struct {
 	ExistingVersions map[string]int64
-	FilesToProcess   map[string]domainindex.FileState
+	FilesToProcess   []domainindex.FileToProcess
 	ContentHashMap   map[string]string
 }
 
@@ -65,6 +65,7 @@ func (s *Service) prepareForProcessingImpl(
 		fileState domainindex.FileState
 		firstPath string
 	})
+	encounterOrder := make([]string, 0)
 	contentHashMap := make(map[string]string)
 
 	for filePath, fileState := range workspaceState.HeadState {
@@ -78,6 +79,7 @@ func (s *Service) prepareForProcessingImpl(
 				fileState domainindex.FileState
 				firstPath string
 			}{fileState: fileState, firstPath: filePath}
+			encounterOrder = append(encounterOrder, fileState.ContentHash)
 		}
 	}
 
@@ -92,6 +94,7 @@ func (s *Service) prepareForProcessingImpl(
 				fileState domainindex.FileState
 				firstPath string
 			}{fileState: fileState, firstPath: filePath}
+			encounterOrder = append(encounterOrder, fileState.ContentHash)
 		}
 	}
 
@@ -106,13 +109,11 @@ func (s *Service) prepareForProcessingImpl(
 				fileState domainindex.FileState
 				firstPath string
 			}{fileState: fileState, firstPath: filePath}
+			encounterOrder = append(encounterOrder, fileState.ContentHash)
 		}
 	}
 
-	contentHashList := make([]string, 0, len(uniqueContentHashes))
-	for contentHash := range uniqueContentHashes {
-		contentHashList = append(contentHashList, contentHash)
-	}
+	contentHashList := append([]string(nil), encounterOrder...)
 
 	existingVersionsMap, err := s.indexRepo.FindVersionsByContentHashes(ctx, contentHashList)
 	if err != nil {
@@ -126,10 +127,14 @@ func (s *Service) prepareForProcessingImpl(
 		}
 	}
 
-	filesToProcess := make(map[string]domainindex.FileState)
-	for contentHash, entry := range uniqueContentHashes {
+	filesToProcess := make([]domainindex.FileToProcess, 0, len(uniqueContentHashes))
+	for _, contentHash := range encounterOrder {
+		entry := uniqueContentHashes[contentHash]
 		if _, exists := existingVersions[contentHash]; !exists {
-			filesToProcess[entry.firstPath] = entry.fileState
+			filesToProcess = append(filesToProcess, domainindex.FileToProcess{
+				FilePath: entry.firstPath,
+				State:    entry.fileState,
+			})
 		}
 	}
 

--- a/internal/core/index/service_test.go
+++ b/internal/core/index/service_test.go
@@ -325,6 +325,52 @@ func TestService_PrepareForProcessing(t *testing.T) {
 		}
 	})
 
+	t.Run("Processes distinct contents for same file path across states", func(t *testing.T) {
+		indexRepo := &mockIndexRepository{}
+		service, _ := NewService(indexRepo, &mockSnapshotRepository{})
+
+		workspaceState := &scanworkspacestate.Output{
+			HeadState: map[string]domainindex.FileState{
+				"shared.ts": {
+					Content:     []byte("head version"),
+					ContentHash: "hash_head",
+				},
+			},
+			StageState: map[string]domainindex.FileState{
+				"shared.ts": {
+					Content:     []byte("stage version"),
+					ContentHash: "hash_stage",
+				},
+			},
+			WorkdirState: map[string]domainindex.FileState{},
+		}
+
+		result, err := service.PrepareForProcessing(context.Background(), workspaceState)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		output := result.(*PrepareOutput)
+		if len(output.FilesToProcess) != 2 {
+			t.Fatalf("Expected 2 files to process, got %d", len(output.FilesToProcess))
+		}
+
+		hashes := make(map[string]struct{})
+		for _, file := range output.FilesToProcess {
+			if file.FilePath != "shared.ts" {
+				t.Errorf("Expected file path shared.ts, got %s", file.FilePath)
+			}
+			hashes[file.State.ContentHash] = struct{}{}
+		}
+
+		if _, ok := hashes["hash_head"]; !ok {
+			t.Error("Expected head content hash to be processed")
+		}
+		if _, ok := hashes["hash_stage"]; !ok {
+			t.Error("Expected stage content hash to be processed")
+		}
+	})
+
 	t.Run("Repository error propagates", func(t *testing.T) {
 		indexRepo := &mockIndexRepository{
 			FindVersionsByContentHashesFunc: func(ctx context.Context, contentHashes []string) (map[string]*domainindex.DocumentVersion, error) {

--- a/internal/domain/index/types.go
+++ b/internal/domain/index/types.go
@@ -67,6 +67,13 @@ type FileState struct {
 	Content     []byte
 }
 
+// FileToProcess represents a unique file (by content) that needs processing.
+// FilePath identifies where the content came from, State holds the file data.
+type FileToProcess struct {
+	FilePath string
+	State    FileState
+}
+
 // CommitSnapshot represents a link between a git commit and a document version.
 // It tracks which document versions existed at a specific commit.
 type CommitSnapshot struct {

--- a/internal/domain/indexservice/types.go
+++ b/internal/domain/indexservice/types.go
@@ -12,7 +12,7 @@ import (
 // PrepareForProcessingOutput represents the output of the PrepareForProcessing operation.
 type PrepareForProcessingOutput struct {
 	ExistingVersions map[string]int64
-	FilesToProcess   map[string]domainindex.FileState
+	FilesToProcess   []domainindex.FileToProcess
 	ContentHashMap   map[string]string
 }
 

--- a/internal/flows/index/reconcile_flow_test.go
+++ b/internal/flows/index/reconcile_flow_test.go
@@ -490,7 +490,7 @@ func TestFactory_NewFlow(t *testing.T) {
 						return func(ctx context.Context, activityCtx *executor.Context, input *deduplicateandprepare.Input) (*deduplicateandprepare.Output, error) {
 							return &deduplicateandprepare.Output{
 								ExistingVersions: make(map[string]int64),
-								FilesToProcess:   make(map[string]domainindex.FileState),
+								FilesToProcess:   []domainindex.FileToProcess{},
 							}, nil
 						}
 					},
@@ -544,12 +544,13 @@ func TestFactory_NewFlow(t *testing.T) {
 				mockDeduplicate := &mockActivityFactory[*deduplicateandprepare.Input, *deduplicateandprepare.Output]{
 					newActivityFunc: func() executor.Activity[*deduplicateandprepare.Input, *deduplicateandprepare.Output] {
 						return func(ctx context.Context, activityCtx *executor.Context, input *deduplicateandprepare.Input) (*deduplicateandprepare.Output, error) {
-							files := map[string]domainindex.FileState{
-								"test.go": {
+							files := []domainindex.FileToProcess{{
+								FilePath: "test.go",
+								State: domainindex.FileState{
 									ContentHash: "hash1",
 									Content:     []byte("content"),
 								},
-							}
+							}}
 							return &deduplicateandprepare.Output{
 								ExistingVersions: make(map[string]int64),
 								FilesToProcess:   files,
@@ -582,7 +583,7 @@ func TestFactory_NewFlow(t *testing.T) {
 					newActivityFunc: func() executor.Activity[*distributeandsave.Input, *distributeandsave.Output] {
 						return func(ctx context.Context, activityCtx *executor.Context, input *distributeandsave.Input) (*distributeandsave.Output, error) {
 							return &distributeandsave.Output{
-								VersionMap: map[string]int64{"test.go": 1},
+								VersionMap: map[string]int64{"hash1": 1},
 							}, nil
 						}
 					},
@@ -638,7 +639,7 @@ func TestFactory_NewFlow(t *testing.T) {
 						return func(ctx context.Context, activityCtx *executor.Context, input *deduplicateandprepare.Input) (*deduplicateandprepare.Output, error) {
 							return &deduplicateandprepare.Output{
 								ExistingVersions: make(map[string]int64),
-								FilesToProcess:   make(map[string]domainindex.FileState),
+								FilesToProcess:   []domainindex.FileToProcess{},
 							}, nil
 						}
 					},
@@ -688,7 +689,7 @@ func TestFactory_NewFlow(t *testing.T) {
 						return func(ctx context.Context, activityCtx *executor.Context, input *deduplicateandprepare.Input) (*deduplicateandprepare.Output, error) {
 							return &deduplicateandprepare.Output{
 								ExistingVersions: make(map[string]int64),
-								FilesToProcess:   make(map[string]domainindex.FileState),
+								FilesToProcess:   []domainindex.FileToProcess{},
 							}, nil
 						}
 					},


### PR DESCRIPTION
Replaced the use of `map[string]domainindex.FileState` with a new `[]domainindex.FileToProcess` slice for representing files that need to be chunked and indexed.

The previous map-based structure did not guarantee a consistent iteration order, leading to non-deterministic behavior in downstream activities. The new `FileToProcess` struct explicitly pairs a file's original path with its state (content hash, etc.).

This change ensures that files are processed in a predictable order, based on when their unique content hash was first encountered. It also improves correctness by preserving original file paths during deduplication and properly handling cases where a single file path has multiple content versions (e.g., in HEAD vs. the git stage).