### PR TITLE
feat(sqlite): add external blob storage for large meta values

### DIFF
--- a/internal/adapters/sqlite/meta/repository.go
+++ b/internal/adapters/sqlite/meta/repository.go
@@ -5,16 +5,36 @@
 package meta
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 
 	"github.com/retran/meowg1k/internal/ports"
 )
 
+const (
+	fileRefPrefix        = "__meowg1k_file__:"
+	maxInlineValueSize   = 8 * 1024 * 1024 // 8 MiB cap for in-DB storage
+	tempBlobFilePattern  = "meta-blob-*"
+	defaultBlobFilePerms = 0o600
+)
+
+var fileRefPrefixBytes = []byte(fileRefPrefix)
+
 // Repository implements metadata storage using SQLite.
 type Repository struct {
-	host ports.Host
+	host        ports.Host
+	blobDirOnce sync.Once
+	blobDir     string
+	blobDirErr  error
 }
 
 // Compile-time interface compliance check.
@@ -33,13 +53,59 @@ func (r *Repository) SetValue(ctx context.Context, key string, value []byte) err
 		return fmt.Errorf("failed to get database: %w", err)
 	}
 
-	_, err = db.ExecContext(ctx,
+	existingRef, err := r.getExistingFileReference(ctx, db, key)
+	if err != nil {
+		return fmt.Errorf("failed to inspect existing value for key '%s': %w", key, err)
+	}
+
+	if len(value) > maxInlineValueSize {
+		blobDir, err := r.ensureBlobDir(db)
+		if err != nil {
+			return fmt.Errorf("failed to prepare blob storage for key '%s': %w", key, err)
+		}
+
+		fileName := r.buildBlobFileName(key, value)
+		if err := r.writeBlob(blobDir, fileName, value); err != nil {
+			return fmt.Errorf("failed to persist blob for key '%s': %w", key, err)
+		}
+
+		sentinel := append([]byte{}, fileRefPrefixBytes...)
+		sentinel = append(sentinel, fileName...)
+
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO meta_kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+			key, sentinel,
+		); err != nil {
+			_ = r.removeBlob(blobDir, fileName) // best effort cleanup on failure
+			return fmt.Errorf("failed to set meta value for key '%s': %w", key, err)
+		}
+
+		if existingRef != "" && existingRef != fileName {
+			if err := r.removeBlob(blobDir, existingRef); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("failed to remove old blob for key '%s': %w", key, err)
+			}
+		}
+
+		return nil
+	}
+
+	if _, err := db.ExecContext(ctx,
 		`INSERT INTO meta_kv (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
 		key, value,
-	)
-	if err != nil {
+	); err != nil {
 		return fmt.Errorf("failed to set meta value for key '%s': %w", key, err)
 	}
+
+	if existingRef != "" {
+		if blobDir, derr := r.ensureBlobDir(db); derr == nil {
+			if err := r.removeBlob(blobDir, existingRef); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("failed to remove obsolete blob for key '%s': %w", key, err)
+			}
+		} else {
+			return fmt.Errorf("failed to clean up blob for key '%s': %w", key, derr)
+		}
+	}
+
 	return nil
 }
 
@@ -59,6 +125,20 @@ func (r *Repository) GetValue(ctx context.Context, key string) ([]byte, error) {
 		}
 		return nil, fmt.Errorf("failed to get meta value for key '%s': %w", key, err)
 	}
+
+	if fileName, ok := parseFileReference(value); ok {
+		blobDir, err := r.ensureBlobDir(db)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve blob storage for key '%s': %w", key, err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(blobDir, fileName))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read blob for key '%s': %w", key, err)
+		}
+		return data, nil
+	}
+
 	return value, nil
 }
 
@@ -70,9 +150,225 @@ func (r *Repository) DeleteValue(ctx context.Context, key string) error {
 		return fmt.Errorf("failed to get database: %w", err)
 	}
 
+	existingRef, err := r.getExistingFileReference(ctx, db, key)
+	if err != nil {
+		return fmt.Errorf("failed to inspect existing value for key '%s': %w", key, err)
+	}
+
 	_, err = db.ExecContext(ctx, "DELETE FROM meta_kv WHERE key = ?", key)
 	if err != nil {
 		return fmt.Errorf("failed to delete meta value for key '%s': %w", key, err)
 	}
+
+	if existingRef != "" {
+		blobDir, derr := r.ensureBlobDir(db)
+		if derr != nil {
+			return fmt.Errorf("failed to resolve blob storage for key '%s': %w", key, derr)
+		}
+		if err := r.removeBlob(blobDir, existingRef); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to remove blob for key '%s': %w", key, err)
+		}
+	}
+
 	return nil
+}
+
+func (r *Repository) ensureBlobDir(db *sql.DB) (string, error) {
+	if db == nil {
+		return "", fmt.Errorf("project database is nil")
+	}
+
+	r.blobDirOnce.Do(func() {
+		dir, err := resolveBlobDir(db)
+		if err != nil {
+			r.blobDirErr = err
+			return
+		}
+		r.blobDir = dir
+	})
+
+	if r.blobDirErr != nil {
+		return "", r.blobDirErr
+	}
+
+	return r.blobDir, nil
+}
+
+func resolveBlobDir(db *sql.DB) (string, error) {
+	rows, err := db.Query("PRAGMA database_list")
+	if err != nil {
+		return "", fmt.Errorf("failed to query database list: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var seq int64
+		var name string
+		var file sql.NullString
+
+		if err := rows.Scan(&seq, &name, &file); err != nil {
+			return "", fmt.Errorf("failed to scan database list: %w", err)
+		}
+
+		if name != "main" {
+			continue
+		}
+
+		if !file.Valid || file.String == "" {
+			return "", fmt.Errorf("main database has no associated file path")
+		}
+
+		dbPath, err := normalizeDBPath(file.String)
+		if err != nil {
+			return "", fmt.Errorf("failed to normalize database path: %w", err)
+		}
+
+		blobDir := filepath.Join(filepath.Dir(dbPath), "meta_blobs")
+		if err := os.MkdirAll(blobDir, 0o750); err != nil {
+			return "", fmt.Errorf("failed to create blob directory: %w", err)
+		}
+
+		return blobDir, nil
+	}
+
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("failed to iterate database list: %w", err)
+	}
+
+	return "", fmt.Errorf("could not locate main database entry")
+}
+
+func normalizeDBPath(raw string) (string, error) {
+	path := strings.TrimSpace(raw)
+
+	if path == "" {
+		return "", fmt.Errorf("database path is empty")
+	}
+
+	if strings.HasPrefix(path, "file:") {
+		path = strings.TrimPrefix(path, "file:")
+	}
+
+	if idx := strings.Index(path, "?"); idx >= 0 {
+		path = path[:idx]
+	}
+
+	path = filepath.Clean(path)
+
+	if !filepath.IsAbs(path) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve absolute path: %w", err)
+		}
+		path = abs
+	}
+
+	return path, nil
+}
+
+func parseFileReference(value []byte) (string, bool) {
+	if len(value) <= len(fileRefPrefixBytes) {
+		return "", false
+	}
+	if !bytes.HasPrefix(value, fileRefPrefixBytes) {
+		return "", false
+	}
+	return string(value[len(fileRefPrefixBytes):]), true
+}
+
+func (r *Repository) getExistingFileReference(ctx context.Context, db *sql.DB, key string) (string, error) {
+	query := `
+		SELECT CASE
+			WHEN substr(value, 1, ?) = ? THEN substr(value, ? + 1)
+			ELSE NULL
+		END
+		FROM meta_kv
+		WHERE key = ?
+	`
+
+	var tail []byte
+	err := db.QueryRowContext(ctx, query,
+		len(fileRefPrefixBytes),
+		fileRefPrefixBytes,
+		len(fileRefPrefixBytes),
+		key,
+	).Scan(&tail)
+
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	if len(tail) == 0 {
+		return "", nil
+	}
+
+	return string(tail), nil
+}
+
+func (r *Repository) buildBlobFileName(key string, value []byte) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(key))
+	hasher.Write([]byte{0})
+	hasher.Write(value)
+	sum := hasher.Sum(nil)
+	return hex.EncodeToString(sum) + ".blob"
+}
+
+func (r *Repository) writeBlob(dir, name string, data []byte) error {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("failed to ensure blob directory: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp(dir, tempBlobFilePattern)
+	if err != nil {
+		return fmt.Errorf("failed to create temp blob file: %w", err)
+	}
+	defer func() {
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("failed to write blob data: %w", err)
+	}
+
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("failed to sync blob data: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp blob file: %w", err)
+	}
+
+	if err := os.Chmod(tmpFile.Name(), defaultBlobFilePerms); err != nil {
+		return fmt.Errorf("failed to set blob file permissions: %w", err)
+	}
+
+	destPath := filepath.Join(dir, name)
+	if err := os.Rename(tmpFile.Name(), destPath); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			if remErr := os.Remove(destPath); remErr != nil && !errors.Is(remErr, os.ErrNotExist) {
+				return fmt.Errorf("failed to replace existing blob file: %w", remErr)
+			}
+			if err := os.Rename(tmpFile.Name(), destPath); err != nil {
+				return fmt.Errorf("failed to finalize blob file: %w", err)
+			}
+		} else {
+			return fmt.Errorf("failed to finalize blob file: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *Repository) removeBlob(dir, name string) error {
+	if dir == "" || name == "" {
+		return nil
+	}
+
+	return os.Remove(filepath.Join(dir, name))
 }

--- a/internal/adapters/sqlite/meta/repository_test.go
+++ b/internal/adapters/sqlite/meta/repository_test.go
@@ -4,10 +4,17 @@
 package meta
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	_ "github.com/ncruces/go-sqlite3/driver"
 
 	"github.com/retran/meowg1k/internal/ports"
 )
@@ -74,7 +81,7 @@ func TestRepository_SetValue_DBError(t *testing.T) {
 		t.Fatal("Expected error when GetProjectDB fails")
 	}
 
-	if !contains(err.Error(), "failed to get database") {
+	if !strings.Contains(err.Error(), "failed to get database") {
 		t.Errorf("Expected 'failed to get database' in error, got: %v", err)
 	}
 }
@@ -94,7 +101,7 @@ func TestRepository_GetValue_DBError(t *testing.T) {
 		t.Fatal("Expected error when GetProjectDB fails")
 	}
 
-	if !contains(err.Error(), "failed to get database") {
+	if !strings.Contains(err.Error(), "failed to get database") {
 		t.Errorf("Expected 'failed to get database' in error, got: %v", err)
 	}
 }
@@ -114,7 +121,7 @@ func TestRepository_DeleteValue_DBError(t *testing.T) {
 		t.Fatal("Expected error when GetProjectDB fails")
 	}
 
-	if !contains(err.Error(), "failed to get database") {
+	if !strings.Contains(err.Error(), "failed to get database") {
 		t.Errorf("Expected 'failed to get database' in error, got: %v", err)
 	}
 }
@@ -137,16 +144,61 @@ func TestRepository_DeleteValue_NonExistentKey(t *testing.T) {
 	t.Skip("Skipping integration test - requires in-memory database")
 }
 
-// Helper function to check if a string contains a substring.
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && hasSubstring(s, substr))
-}
+func TestRepository_LargeValueStoredExternally(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "project.db")
 
-func hasSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
+	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?_foreign_keys=on", dbPath))
+	if err != nil {
+		t.Fatalf("failed to open sqlite database: %v", err)
 	}
-	return false
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE meta_kv (key TEXT PRIMARY KEY, value BLOB NOT NULL);`); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	host := &mockHost{
+		GetProjectDBFunc: func() (*sql.DB, error) {
+			return db, nil
+		},
+	}
+
+	repo := NewRepository(host)
+	ctx := context.Background()
+
+	largeValue := bytes.Repeat([]byte{0x2A}, maxInlineValueSize+1024)
+	if err := repo.SetValue(ctx, "large-key", largeValue); err != nil {
+		t.Fatalf("SetValue failed: %v", err)
+	}
+
+	readBack, err := repo.GetValue(ctx, "large-key")
+	if err != nil {
+		t.Fatalf("GetValue failed: %v", err)
+	}
+
+	if !bytes.Equal(readBack, largeValue) {
+		t.Fatal("retrieved value does not match original large payload")
+	}
+
+	metaBlobDir := filepath.Join(tempDir, "meta_blobs")
+	entries, err := os.ReadDir(metaBlobDir)
+	if err != nil {
+		t.Fatalf("failed to read blob directory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 blob file, found %d", len(entries))
+	}
+
+	if err := repo.DeleteValue(ctx, "large-key"); err != nil {
+		t.Fatalf("DeleteValue failed: %v", err)
+	}
+
+	entries, err = os.ReadDir(metaBlobDir)
+	if err != nil {
+		t.Fatalf("failed to read blob directory after delete: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected blob directory to be empty after delete, found %d files", len(entries))
+	}
 }


### PR DESCRIPTION
To prevent database bloat and potential performance issues, values exceeding 8MB are no longer stored directly in the `meta_kv` table.

This change introduces a hybrid storage system where large values are written to external files in a `meta_blobs` directory, which is created adjacent to the main database file. The `meta_kv` table now stores a special reference string pointing to the corresponding blob file.

The `SetValue`, `GetValue`, and `DeleteValue` methods in the meta repository have been updated to handle this logic transparently, managing the lifecycle of blob files automatically.