### PR TITLE
fix: upgrade trivy-action to v0.35.0 to patch command injection vulnerability

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -211,7 +211,7 @@ jobs:
           go list -json -deps ./... | nancy sleuth || echo "Nancy scan completed"
 
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.32.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
## Summary

- Upgrades `aquasecurity/trivy-action` from `@0.32.0` to `@0.35.0` (pinned to commit SHA `57a97c7e7821a5776cebc9bb87c984fa69cba8f1`) in `.github/workflows/nightly.yaml`.

## Security

**Vulnerability**: Command injection in `aquasecurity/trivy-action` via unsanitized environment variable export.

**Affected versions**: `>= 0.31.0` and `<= 0.33.1`

**CVE details**:
- CWE-78: Improper Neutralization of Special Elements used in OS Command
- CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:N (Moderate)

**Root cause**: The action writes `export VAR=<input>` lines to `trivy_envs.txt` without shell-escaping user-supplied inputs, then sources that file in `entrypoint.sh`. Attacker-controlled input containing shell metacharacters (`$(...)`, backticks, etc.) can result in arbitrary command execution in the CI runner.

**This repo's exposure**: The `nightly.yaml` workflow used `@0.32.0` (in the affected range) with a static `output: 'trivy-results.sarif'` — no attacker-controlled data is passed to inputs, so the practical risk here was low. Upgrading eliminates the vulnerability class entirely regardless.

**Fix**: Upgrade to `v0.35.0`, the latest release, which is past the affected range and pins to a verified commit SHA per existing workflow conventions.